### PR TITLE
Fix wrong reference to posting key

### DIFF
--- a/src/common/pages/communities.tsx
+++ b/src/common/pages/communities.tsx
@@ -402,7 +402,7 @@ class CommunityCreatePage extends BaseComponent<PageProps, CreateState> {
         try {
             await keychain.addAccount(username, {
                 active: keys.activeKey.toString(),
-                posting: keys.activeKey.toString(),
+                posting: keys.postingKey.toString(),
                 memo: keys.memoKey.toString()
             });
         } catch (e) {


### PR DESCRIPTION
The posting key was being populated with the active key, instead of the former one.