### PR TITLE
Add edit/delete buttons only

### DIFF
--- a/src/common/api/operations.ts
+++ b/src/common/api/operations.ts
@@ -56,6 +56,8 @@ const handleChainError = (strErr: string) => {
         return _t("chain-error.insufficient-resource");
     } else if (/Cannot delete a comment with net positive/.test(strErr)) {
         return _t("chain-error.delete-comment-with-vote");
+    } else if (/children == 0/.test(strErr)) {
+        return _t("chain-error.comment-children");
     } else if (/comment_cashout/.test(strErr)) {
         return _t("chain-error.comment-cashout");
     } else if (/Votes evaluating for comment that is paid out is forbidden/.test(strErr)) {

--- a/src/common/components/discussion/index.tsx
+++ b/src/common/components/discussion/index.tsx
@@ -329,7 +329,7 @@ export class Item extends BaseComponent<ItemProps, ItemState> {
                                     }}>{_t("discussion.reveal")}</Button>
                                 </div>
                             }
-                            debugger
+                            
                             return <>
                                 <ItemBody global={this.props.global} entry={entry}/>
                                 <div className="item-controls">

--- a/src/common/components/discussion/index.tsx
+++ b/src/common/components/discussion/index.tsx
@@ -329,7 +329,7 @@ export class Item extends BaseComponent<ItemProps, ItemState> {
                                     }}>{_t("discussion.reveal")}</Button>
                                 </div>
                             }
-
+                            debugger
                             return <>
                                 <ItemBody global={this.props.global} entry={entry}/>
                                 <div className="item-controls">
@@ -363,7 +363,7 @@ export class Item extends BaseComponent<ItemProps, ItemState> {
                                             <a title={_t('g.edit')} className={_c(`edit-btn ${reply ? 'disabled' : ''}`)} onClick={this.toggleEdit}>
                                                 {pencilOutlineSvg}
                                             </a>
-                                            {entry.net_rshares > 0 || entry.children > 0 ? null : EntryDeleteBtn({
+                                            {(entry.is_paidout || entry.net_rshares > 0 || entry.children > 0) ? null : EntryDeleteBtn({
                                                 ...this.props,
                                                 entry,
                                                 onSuccess: this.deleted,

--- a/src/common/components/discussion/index.tsx
+++ b/src/common/components/discussion/index.tsx
@@ -363,7 +363,7 @@ export class Item extends BaseComponent<ItemProps, ItemState> {
                                             <a title={_t('g.edit')} className={_c(`edit-btn ${reply ? 'disabled' : ''}`)} onClick={this.toggleEdit}>
                                                 {pencilOutlineSvg}
                                             </a>
-                                            {EntryDeleteBtn({
+                                            {entry.net_rshares > 0 || entry.children > 0 ? null : EntryDeleteBtn({
                                                 ...this.props,
                                                 entry,
                                                 onSuccess: this.deleted,

--- a/src/common/components/entry-delete-btn/index.tsx
+++ b/src/common/components/entry-delete-btn/index.tsx
@@ -16,7 +16,9 @@ interface Props {
     children: JSX.Element;
     entry: Entry;
     activeUser: ActiveUser | null;
-    onSuccess: () => void
+    onSuccess: () => void;
+    setDeleteInProgress?: (value: boolean) => void;
+    isComment?: boolean;
 }
 
 interface State {
@@ -29,17 +31,20 @@ export class EntryDeleteBtn extends BaseComponent<Props> {
     };
 
     delete = () => {
-        const {entry, activeUser, onSuccess} = this.props;
+        const {entry, activeUser, onSuccess, setDeleteInProgress} = this.props;
+        setDeleteInProgress && setDeleteInProgress(true);
 
         this.stateSet({inProgress: true});
         deleteComment(activeUser?.username!, entry.author, entry.permlink)
             .then(() => {
                 onSuccess();
                 this.stateSet({inProgress: false});
+                setDeleteInProgress && setDeleteInProgress(false);
             })
             .catch((e) => {
                 error(formatError(e));
                 this.stateSet({inProgress: false});
+                setDeleteInProgress && setDeleteInProgress(false);
             })
     };
 
@@ -71,7 +76,8 @@ export default (props: Props) => {
         children: props.children,
         entry: props.entry,
         activeUser: props.activeUser,
-        onSuccess: props.onSuccess
+        onSuccess: props.onSuccess,
+        setDeleteInProgress: props.setDeleteInProgress
     }
 
     return <EntryDeleteBtn {...p} />

--- a/src/common/components/entry-menu/index.tsx
+++ b/src/common/components/entry-menu/index.tsx
@@ -48,6 +48,7 @@ interface Props {
     dynamicProps: DynamicProps;
     activeUser: ActiveUser | null;
     entry: Entry;
+    extraMenuItems?: any[];
     communities: Communities;
     entryPinTracker: EntryPinTracker;
     separatedSharing?: boolean;
@@ -231,7 +232,7 @@ export class EntryMenu extends BaseComponent<Props, State> {
     }
 
     render() {
-        const {global, activeUser, entry, entryPinTracker, alignBottom, separatedSharing} = this.props;
+        const {global, activeUser, entry, entryPinTracker, alignBottom, separatedSharing, extraMenuItems} = this.props;
        
         const isComment = !!entry.parent_author;
 
@@ -348,6 +349,13 @@ export class EntryMenu extends BaseComponent<Props, State> {
             ]
         }
 
+        if(extraMenuItems){
+            menuItems = [
+                ...menuItems,
+                ...extraMenuItems
+            ]
+        }
+
         const menuConfig = {
             history: this.props.history,
             label: '',
@@ -439,6 +447,7 @@ export default (p: Props) => {
         separatedSharing: p.separatedSharing,
         alignBottom: p.alignBottom,
         signingKey: p.signingKey,
+        extraMenuItems: p.extraMenuItems,
         setSigningKey: p.setSigningKey,
         updateActiveUser: p.updateActiveUser,
         updateEntry: p.updateEntry,

--- a/src/common/components/entry-menu/index.tsx
+++ b/src/common/components/entry-menu/index.tsx
@@ -282,7 +282,14 @@ export class EntryMenu extends BaseComponent<Props, State> {
                         label: _t("g.edit"),
                         onClick: this.edit,
                         icon: pencilOutlineSvg
-                    },
+                    }
+                ]
+            ];
+        }
+
+        if (!(entry.children > 0 || entry.net_rshares > 0 || entry.is_paidout)) {
+            menuItems = [...menuItems,
+                ...[
                     {
                         label: _t("g.delete"),
                         onClick: this.toggleDelete,

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -271,6 +271,7 @@
     "comment-entry-go-root": "View the full context",
     "comment-entry-go-parent": "View the direct parent",
     "hidden-warning": "This content got low rating by people. Proceed with caution.",
+    "delete-disabled": "Content after their payout cannot be deleted.",
     "muted-warning": "This content was muted by {{community}} moderators for not following community guidelines.",
     "lowrep-warning": "Author of this post has low reputation. Proceed with caution.",
     "comments-hidden": "Author of this post is muted by you.",
@@ -1095,8 +1096,9 @@
     "min-root-comment": "You may only post once every five minutes.",
     "identical-vote": "Your current vote on this content is identical to this vote.",
     "insufficient-resource": "Insufficient Resource Credits. Please wait to transact, or power up HIVE.",
-    "delete-comment-with-vote": "Can't delete a content with votes.",
-    "comment-cashout": "Content cashout.",
+    "delete-comment-with-vote": "Cannot delete a content with positive pending rewards.",
+    "comment-cashout": "Content after their payout cannot be deleted.",
+    "comment-children": "Cannot delete a content with replies.",
     "paid-out-post-forbidden": "Voting for paid out content is not available."
   },
   "landing-page": {

--- a/src/common/pages/_entry.scss
+++ b/src/common/pages/_entry.scss
@@ -16,6 +16,27 @@
     background: $dark-grey-blue;
   }
 }
+.edit-btn {
+  width: 20px;
+  height: 20px;
+  margin-right: 14px;
+  cursor: pointer;
+  @include themify(day) {
+    color: $steel-grey;
+  }
+
+  @include themify(night) {
+    color: lighten($steel-grey, 4);
+  }
+
+  &:hover {
+    color: $dark-sky-blue;
+  }
+}
+
+.bookmark-btn {
+  margin-right: 0px !important;
+}
 
 .entry-page {
   font-family: Georgia, -apple-system, BlinkMacSystemFont, sans-serif;

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -111,14 +111,11 @@ class EntryPage extends BaseComponent<Props, State> {
     componentDidMount() {
         this.ensureEntry();
         this.fetchMutedUsers()
-        let entry = this.getEntry();
 
         const {location, global} = this.props;
         if (global.usePrivate && location.search === "?history") {
             this.toggleEditHistory();
         }
-        entry && this.setState({comment: this.getEntry()!.body || ""})
-
         window.addEventListener("scroll", this.detect);
         window.addEventListener("resize", this.detect);
 
@@ -127,11 +124,7 @@ class EntryPage extends BaseComponent<Props, State> {
     componentDidUpdate(prevProps: Readonly<Props>): void {
         const {location} = this.props;
         if (location.pathname !== prevProps.location.pathname) {
-            this.ensureEntry();
-            let entry = this.getEntry();
-            if(entry && entry.parent_author){
-                this.setState({ comment: entry && entry.body || "" })
-            }
+            this.ensureEntry()
         }
     }
 
@@ -225,6 +218,7 @@ class EntryPage extends BaseComponent<Props, State> {
         const {category, username, permlink} = match.params;
         const author = username.replace("@", "");
 
+        
         let reducerFn = updateEntry;
 
         if (!entry) {
@@ -533,8 +527,8 @@ class EntryPage extends BaseComponent<Props, State> {
                                         if (originalEntry) {
                                             const published = moment(parseDate(originalEntry.created));
                                             const reputation = accountReputation(originalEntry.author_reputation);
-                                            const renderedBody = {__html: renderPostBody(isComment ? comment.length > 0 && comment || originalEntry.body : originalEntry.body, false, global.canUseWebp)};
-
+                                            const renderedBody = {__html: renderPostBody(originalEntry.body, false, global.canUseWebp)};
+                                            
                                             return <>
                                                 <div className="entry-header">
                                                     <h1 className="entry-title">
@@ -601,7 +595,8 @@ class EntryPage extends BaseComponent<Props, State> {
                                             </>;
                                         }
 
-                                        const renderedBody = {__html: renderPostBody(isComment ? comment.length > 0 && comment || entry.body : entry.body, false, global.canUseWebp)};
+                                        const renderedBody = {__html: renderPostBody(isComment ? comment.length > 0 ? comment : entry.body :entry.body, false, global.canUseWebp)};
+                                        
                                         const ctitle = entry.community ? entry.community_title : "";
                                         let extraItems = ownEntry && isComment ? [{
                                                 label: _t("g.edit"),
@@ -726,7 +721,7 @@ class EntryPage extends BaseComponent<Props, State> {
                                                 <div itemProp="articleBody" className="entry-body markdown-view user-selectable" dangerouslySetInnerHTML={renderedBody}/> :
                                                 Comment({
                                                     ...this.props,
-                                                    defText: comment,
+                                                    defText: entry.body,
                                                     submitText: _t('g.update'),
                                                     cancellable: true,
                                                     onSubmit: this.updateReply,

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -435,7 +435,7 @@ class EntryPage extends BaseComponent<Props, State> {
         const appShort = app.split('/')[0].split(' ')[0];
 
         const isComment = !!entry.parent_author;
-debugger
+
         const {activeUser} = this.props;
 
         const ownEntry = activeUser && activeUser.username === entry.author;
@@ -603,6 +603,26 @@ debugger
 
                                         const renderedBody = {__html: renderPostBody(isComment ? comment.length > 0 && comment || entry.body : entry.body, false, global.canUseWebp)};
                                         const ctitle = entry.community ? entry.community_title : "";
+                                        let extraItems = ownEntry && isComment ? [{
+                                                label: _t("g.edit"),
+                                                onClick: this.toggleEdit,
+                                                icon: pencilOutlineSvg
+                                            }
+                                        ] : [];
+                                        if(!(entry.children > 0 || entry.net_rshares > 0 || entry.is_paidout) && ownEntry && isComment){
+                                            extraItems = [...extraItems, {
+                                                label: "",
+                                                onClick: ()=>{},
+                                                icon: entryDeleteBtn({
+                                                    ...this.props,
+                                                    entry,
+                                                    setDeleteInProgress: value=> this.setState({loading: value}),
+                                                    onSuccess: this.deleted,
+                                                    children: <a title={_t('g.delete')} className="edit-btn">{deleteForeverSvg} {_t("g.delete")}</a>
+                                                })
+                                            }]
+                                            }
+
                                         return <>
                                             <div className="entry-header">
                                                 {isMuted && (<div className="hidden-warning">
@@ -697,34 +717,7 @@ debugger
                                                         ...this.props,
                                                         entry,
                                                         separatedSharing: true,
-                                                        extraMenuItems: ownEntry && isComment ? [{
-                                                            label: _t("g.edit"),
-                                                            onClick: this.toggleEdit,
-                                                            icon: pencilOutlineSvg
-                                                        },
-                                                        {
-                                                            label: "",
-                                                            onClick: ()=>{},
-                                                            icon: entryDeleteBtn({
-                                                                ...this.props,
-                                                                entry,
-                                                                setDeleteInProgress: value=> this.setState({loading: value}),
-                                                                onSuccess: this.deleted,
-                                                                children: (entry.children > 0 || entry.net_rshares > 0) ? <>{null}</> : entry && entry.is_paidout ? <OverlayTrigger
-                                                                delay={{ show: 0, hide: 500 }}
-                                                                key={'bottom'}
-                                                                placement={'bottom'}
-                                                                overlay={
-                                                                    <Tooltip id={`tooltip-votes-${'bottom'}`}>
-                                                                        {_t('entry.delete-disabled')}
-                                                                    </Tooltip>
-                                                                }
-                                                                >
-                                                                <a className="edit-btn text-muted">{deleteForeverSvg} {_t("g.delete")}</a>
-                                                            </OverlayTrigger> : <a title={_t('g.delete')} className="edit-btn">{deleteForeverSvg} {_t("g.delete")}</a>
-                                                            })
-                                                        }
-                                                    ] : []
+                                                        extraMenuItems: extraItems
                                                     })}
                                                 </div>
                                             </div>

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -435,7 +435,7 @@ class EntryPage extends BaseComponent<Props, State> {
         const appShort = app.split('/')[0].split(' ')[0];
 
         const isComment = !!entry.parent_author;
-
+debugger
         const {activeUser} = this.props;
 
         const ownEntry = activeUser && activeUser.username === entry.author;
@@ -697,7 +697,7 @@ class EntryPage extends BaseComponent<Props, State> {
                                                         ...this.props,
                                                         entry,
                                                         separatedSharing: true,
-                                                        extraMenuItems : ownEntry && isComment ? [{
+                                                        extraMenuItems: ownEntry && isComment ? [{
                                                             label: _t("g.edit"),
                                                             onClick: this.toggleEdit,
                                                             icon: pencilOutlineSvg
@@ -710,7 +710,7 @@ class EntryPage extends BaseComponent<Props, State> {
                                                                 entry,
                                                                 setDeleteInProgress: value=> this.setState({loading: value}),
                                                                 onSuccess: this.deleted,
-                                                                children: entry && entry.is_paidout ? <OverlayTrigger
+                                                                children: (entry.children > 0 || entry.net_rshares > 0) ? <>{null}</> : entry && entry.is_paidout ? <OverlayTrigger
                                                                 delay={{ show: 0, hide: 500 }}
                                                                 key={'bottom'}
                                                                 placement={'bottom'}


### PR DESCRIPTION
This PR:

- adds edit and delete buttons only

- If user navigates to a newly added comment, they see 404 as already happening on ecency.com, did not touch to fix this. Reloading the page works as ecency.com does i.e. no 404 after a while but respective comment page but with Edit/Delete buttons.

- Updating a comment shows immediate effects but when user navigates back to the parent post, it shows old value and after some time, it shows edited value. Same happens on ecency.com when user edits a comment, there are immediate effects on that page. Then if user goes to the comment page, old value is there, comes back, old value is there. It takes several moments to update there.

- Everything else is working as previously