### PR TITLE
Added distinction between vote change and removal

### DIFF
--- a/src/common/components/entry-vote-btn/_index.scss
+++ b/src/common/components/entry-vote-btn/_index.scss
@@ -421,7 +421,7 @@ p {
 
 .vote-warning {
   font-size: 12px;
-  color: $yellow;
+  color: $gray-600;
   display: flex;
   justify-content: center;
   margin-top: 8px;

--- a/src/common/components/entry-vote-btn/_index.scss
+++ b/src/common/components/entry-vote-btn/_index.scss
@@ -438,6 +438,25 @@ p {
   }
 }
 
+.vote-remove {
+  font-size: 12px;
+  color: $yellow;
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+p {
+  margin:0px;
+}
+
+  @media screen and (max-width: 480px) {
+    p {
+      width: 90%;
+      text-align: center;
+      white-space: pre-wrap;
+    }
+  }
+}
+
 .primary-btn-vote svg {
   transform: rotate(0deg) !important;
 }

--- a/src/common/components/entry-vote-btn/index.tsx
+++ b/src/common/components/entry-vote-btn/index.tsx
@@ -59,6 +59,7 @@ interface VoteDialogState {
   mode: Mode;
   wrongValueUp: boolean;
   showWarning: boolean;
+  showRemove: boolean;
   wrongValueDown: boolean;
   initialVoteValues: { up: any; down: any };
 }
@@ -72,6 +73,7 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
     wrongValueUp: false,
     wrongValueDown: false,
     showWarning: false,
+    showRemove: false,
     initialVoteValues: {
       up: getVoteValue("up", this.props.activeUser?.username! + '-' + this.props.entry.post_id,  getVoteValue("upPrevious", this.props.activeUser?.username!, 100)),
       down: getVoteValue("down", this.props.activeUser?.username!+ '-' + this.props.entry.post_id,  getVoteValue("downPrevious", this.props.activeUser?.username!, -1)),
@@ -143,22 +145,21 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
     this.setState({
       upSliderVal,
       wrongValueUp: upSliderVal === initialVoteValues.up && upVoted,
-      showWarning: upSliderVal < initialVoteValues.up && (upVoted) 
+      showRemove: upSliderVal === 0 && upVoted,
+      showWarning: (upSliderVal < initialVoteValues.up || upSliderVal > initialVoteValues.up) && upSliderVal > 0 && upVoted
     });
   };
 
-  downSliderChanged = (
-    e: React.ChangeEvent<typeof FormControl & HTMLInputElement>
-  ) => {
+  downSliderChanged = (e: React.ChangeEvent<typeof FormControl & HTMLInputElement>) => {
     const { target: { id, value} } = e;
-
     const downSliderVal = Number(value);
     const { initialVoteValues } = this.state;
     const { upVoted, downVoted } = this.props;
     this.setState({
       downSliderVal,
       wrongValueDown: downSliderVal === initialVoteValues.up,
-      showWarning: downSliderVal > initialVoteValues.down && (downVoted)
+      showRemove: downSliderVal === 0 && downVoted,
+      showWarning: (downSliderVal > initialVoteValues.down || downSliderVal < initialVoteValues.down) && downSliderVal < 0 && downVoted
     });
   };
 
@@ -219,7 +220,7 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
   };
 
   render() {
-    const { upSliderVal, downSliderVal, mode, wrongValueUp, wrongValueDown, showWarning } = this.state;
+    const { upSliderVal, downSliderVal, mode, wrongValueUp, wrongValueDown, showWarning, showRemove } = this.state;
     const { entry: { post_id } } = this.props;
 
     return (
@@ -275,6 +276,11 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
                 <p>{_t('entry-list-item.vote-warning')}</p>
               </div>
             )}
+            {showRemove && (
+              <div className="vote-remove">
+                <p>{_t('entry-list-item.vote-remove')}</p>
+              </div>
+            )}
           </>
         )}
 
@@ -326,6 +332,11 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
             {showWarning && (
               <div className="vote-warning">
                 <p>{_t('entry-list-item.vote-warning')}</p>
+              </div>
+            )}
+            {showRemove && (
+              <div className="vote-remove">
+                <p>{_t('entry-list-item.vote-remove')}</p>
               </div>
             )}
           </>

--- a/src/common/constants/contributors.json
+++ b/src/common/constants/contributors.json
@@ -352,5 +352,13 @@
     "contributes":[
       "Thought Leader"
     ]
+  },
+  {
+    "name": "forykw",
+    "contributes":[
+      "Tester",
+      "Troubleshooter",
+      "Developer"
+    ]
   }
 ]

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -175,7 +175,8 @@
     "replies": "1 response. Click to respond.",
     "replies-n": "{{n}} responses. Click to respond.",
     "vote-error": "Previous value is not acceptable. Vote with a different value.",
-    "vote-warning": "Voting 0% unvotes the content.",
+    "vote-remove": "Voting 0% unvotes the content.",
+    "vote-warning": "Changing already voted content.",
     "no-replies": "No responses yet. Click to respond."
   },
   "nsfw": {

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -176,7 +176,7 @@
     "replies-n": "{{n}} responses. Click to respond.",
     "vote-error": "Previous value is not acceptable. Vote with a different value.",
     "vote-remove": "Voting 0% unvotes the content.",
-    "vote-warning": "Changing already voted content.",
+    "vote-warning": "Changing vote...",
     "no-replies": "No responses yet. Click to respond."
   },
   "nsfw": {


### PR DESCRIPTION
Hi @feruzm, this is a better description of what happens behind the scenes when re-voting is 0% or changed the current vote from what was previsouly.

Tested on my local instance as working correctly.

Needs all the other languages to change `vote-warning` to `vote-remove` and add what it really means vote-warning in this case.

Cheers