### PR TITLE
bug fixed by providing boundariesElement prop to plugin

### DIFF
--- a/src/common/components/textarea-autocomplete/index.tsx
+++ b/src/common/components/textarea-autocomplete/index.tsx
@@ -77,6 +77,7 @@ export default class TextareaAutocomplete extends BaseComponent<any, State> {
 				value={this.state.value}
 				placeholder={this.props.placeholder}
 				onChange={this.handleChange}
+				boundariesElement={".body-input"}
 				minChar={2}
 				trigger={{
 					["@"]: {


### PR DESCRIPTION
Studied the React Textarea Autocomplete plugin that we are using and it has a boundariesElement prop. Now the Autocomplete popup will stay in the editor even if the cursor is at the bottom or at the right mode side of the editor.