### PR TITLE
Images rendering in comment section issue.

### DIFF
--- a/src/style/_markdown.scss
+++ b/src/style/_markdown.scss
@@ -404,12 +404,12 @@
       font-size: 16px;
     }
 
-    img {
-      @media (min-width: $md-break) {
-        width: 100%;
-        max-width: 400px;
-      }
-    }
+    // img {
+    //   @media (min-width: $md-break) {
+    //     width: 100%;
+    //     max-width: 400px;
+    //   }
+    // }
 
     .markdown-video-link {
       width: 240px;


### PR DESCRIPTION
Debugged and find that the CSS for the mini-markdown image needs to change. I have fixed the issue to the best of my understanding from the comments on https://github.com/ecency/ecency-vision/issues/793.
Let me know if something is missing.