### PR TITLE
Support 30 characters logic

### DIFF
--- a/src/common/components/textarea-autocomplete/_index.scss
+++ b/src/common/components/textarea-autocomplete/_index.scss
@@ -13,6 +13,8 @@
 
     .rta__list {
       list-style: none;
+      padding: 0px;
+
       overflow-x: auto;
       @include themify(day) {
         background: $white-two;

--- a/src/common/components/textarea-autocomplete/_index.scss
+++ b/src/common/components/textarea-autocomplete/_index.scss
@@ -9,6 +9,7 @@
     overflow: auto !important;
     min-width: 200px;
     position: absolute;
+    top: 20px !important;
 
     .rta__list {
       list-style: none;

--- a/src/common/components/textarea-autocomplete/_index.scss
+++ b/src/common/components/textarea-autocomplete/_index.scss
@@ -13,8 +13,6 @@
     .rta__list {
       list-style: none;
       overflow-x: auto;
-      padding-left: 10px;
-      margin-left: 30px;
       @include themify(day) {
         background: $white-two;
       }

--- a/src/common/components/textarea-autocomplete/_index.scss
+++ b/src/common/components/textarea-autocomplete/_index.scss
@@ -13,6 +13,8 @@
     .rta__list {
       list-style: none;
       overflow-x: auto;
+      padding-left: 10px;
+      margin-left: 30px;
       @include themify(day) {
         background: $white-two;
       }

--- a/src/common/components/textarea-autocomplete/index.tsx
+++ b/src/common/components/textarea-autocomplete/index.tsx
@@ -106,7 +106,7 @@ export default class TextareaAutocomplete extends BaseComponent<any, State> {
 						},
 						component: (props: any) => {
 							let textToShow: string = props.entity.includes("/") ? props.entity.split("/")[1] : props.entity;
-							let charLimit = isMobile() ? 10 : 30
+							let charLimit = isMobile() ? 16 : 30
 							
 							if(textToShow.length > charLimit && props.entity.includes("/")){
 								textToShow = textToShow.substring(0, charLimit - 5) + "..." + textToShow.substring(textToShow.length - 6, textToShow.length-1)

--- a/src/common/components/textarea-autocomplete/index.tsx
+++ b/src/common/components/textarea-autocomplete/index.tsx
@@ -8,6 +8,7 @@ import { _t } from "../../i18n";
 
 import { lookupAccounts } from "../../api/hive";
 import { searchPath } from '../../api/search-api';
+import { isMobile } from '../../util/is-mobile';
 
 interface State {
 	value: string;
@@ -105,9 +106,10 @@ export default class TextareaAutocomplete extends BaseComponent<any, State> {
 						},
 						component: (props: any) => {
 							let textToShow: string = props.entity.includes("/") ? props.entity.split("/")[1] : props.entity;
+							let charLimit = isMobile() ? 10 : 30
 							
-							if(textToShow.length > 30){
-								textToShow = textToShow.substring(0, 25) + "..." + textToShow.substring(textToShow.length - 6, textToShow.length-1)
+							if(textToShow.length > charLimit){
+								textToShow = textToShow.substring(0, charLimit - 5) + "..." + textToShow.substring(textToShow.length - 6, textToShow.length-1)
 							}
 
 							return (

--- a/src/common/components/textarea-autocomplete/index.tsx
+++ b/src/common/components/textarea-autocomplete/index.tsx
@@ -104,10 +104,16 @@ export default class TextareaAutocomplete extends BaseComponent<any, State> {
 							});
 						},
 						component: (props: any) => {
+							let textToShow: string = props.entity.includes("/") ? props.entity.split("/")[1] : props.entity;
+							
+							if(textToShow.length > 30){
+								textToShow = textToShow.substring(0, 25) + "..." + textToShow.substring(textToShow.length - 6, textToShow.length-1)
+							}
+
 							return (
 								<>
 									{props.entity.includes("/") ? null : UserAvatar({ global: this.props.global, username: props.entity, size: "small" })}
-									<span style={{ marginLeft: "8px" }}>{props.entity}</span>
+									<span style={{ marginLeft: "8px" }}>{textToShow}</span>
 								</>
 							)
 						},

--- a/src/common/components/textarea-autocomplete/index.tsx
+++ b/src/common/components/textarea-autocomplete/index.tsx
@@ -108,7 +108,7 @@ export default class TextareaAutocomplete extends BaseComponent<any, State> {
 							let textToShow: string = props.entity.includes("/") ? props.entity.split("/")[1] : props.entity;
 							let charLimit = isMobile() ? 10 : 30
 							
-							if(textToShow.length > charLimit){
+							if(textToShow.length > charLimit && props.entity.includes("/")){
 								textToShow = textToShow.substring(0, charLimit - 5) + "..." + textToShow.substring(textToShow.length - 6, textToShow.length-1)
 							}
 

--- a/src/common/util/is-mobile.tsx
+++ b/src/common/util/is-mobile.tsx
@@ -1,0 +1,15 @@
+import React, { useEffect } from 'react';
+
+export function isMobile() {
+  const [screenWidth, setScreenWidth] = React.useState(typeof window !== "undefined" && window.innerWidth)
+
+  useEffect(() => {
+    function handleResize() {
+        setScreenWidth(window.innerWidth);
+}
+
+    window.addEventListener('resize', handleResize)
+  })
+
+  return screenWidth < 570
+} 


### PR DESCRIPTION
This closes #802

This PR addresses the following:
- Popup was covering the text on electron, Fixed.
- Popup got hidden when options were long, fixed for mobile/web/electron
- Truncated values are shown in dropdown, full values after selection
- Add isMobile() hook
- Electron had half width of input
- Electron had popup displaced at the bottom