### PR TITLE
notification infinite scroll issue

### DIFF
--- a/src/common/components/notifications/index.tsx
+++ b/src/common/components/notifications/index.tsx
@@ -253,6 +253,14 @@ export class DialogContent extends Component<NotificationProps, any> {
     const { notifications } = this.props;
     const { list, loading, filter, hasMore, unread } = notifications;
 
+    const handleScroll = (event: React.UIEvent<HTMLElement>) => {
+      var element = event.currentTarget;
+      let srollHeight: number = (element.scrollHeight / 100) * 75;
+      if (element.scrollTop >= srollHeight && hasMore) {
+        this.loadMore();
+      }
+    };
+
     return (
       <div className="notification-list">
         <div className="list-header">
@@ -362,21 +370,13 @@ export class DialogContent extends Component<NotificationProps, any> {
         )}
 
         {list.length > 0 && (
-          <div className="list-body">
+          <div className="list-body" onScroll={handleScroll}>
             {list.map((n) => (
               <Fragment key={n.id}>
                 {n.gkf && <div className="group-title">{date2key(n.gk)}</div>}
                 <NotificationListItem {...this.props} notification={n} />
               </Fragment>
             ))}
-
-            {hasMore && (
-              <div className="load-more">
-                <Button disabled={loading} block={true} onClick={this.loadMore}>
-                  Load More
-                </Button>
-              </div>
-            )}
           </div>
         )}
         {loading && list.length > 0 && <LinearProgress />}


### PR DESCRIPTION
**What does this PR?**
"load more" button is no more showing.
fetch notifications by infinite scroll.

**Steps to reproduce**
click on notification icon to see all notifications.
scroll towards the bottom and observe that infinite scroll is working.

**Issue number**
fixes #[1049](https://github.com/ecency/ecency-vision/issues/1049)

**Screenshots/Video**

https://user-images.githubusercontent.com/106739598/199214028-ea2b8db9-6b7c-439d-8b95-e7fea4c59caf.mp4

**Feedback Resolved**


https://user-images.githubusercontent.com/106739598/199703219-1d8ffeda-3a8c-48b8-b411-bfa006dae993.mp4

