### PR TITLE
Added coingecko proxy via server with a caching

### DIFF
--- a/src/common/components/market-swap-form/api/coingecko-api.ts
+++ b/src/common/components/market-swap-form/api/coingecko-api.ts
@@ -8,16 +8,12 @@ interface CoinGeckoApiResponse {
 }
 
 const getCGMarketApi = async (ids: string, vs: string): Promise<CoinGeckoApiResponse> => {
-  const resp = await axios.get<CoinGeckoApiResponse>(
-    "https://api.coingecko.com/api/v3/simple/price",
-    {
-      params: {
-        ids,
-        vs_currencies: vs,
-        include_24hr_change: false
-      }
+  const resp = await axios.get<CoinGeckoApiResponse>("/coingecko/api/v3/simple/price", {
+    params: {
+      ids,
+      vs_currencies: vs
     }
-  );
+  });
   return resp.data;
 };
 

--- a/src/server/handlers/coingecko.handler.ts
+++ b/src/server/handlers/coingecko.handler.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import { getCGMarketApi } from "../services";
+import { cache } from "../cache";
+
+export const coingeckoHandler = async (req: express.Request, res: express.Response) => {
+  try {
+    const data = await getCGMarketApi(req.query.ids as string, req.query.vs_currencies as string);
+    cache.set(req.url, data);
+    res.send(data);
+  } catch (e) {
+    const hasCached = cache.has(((req.query.ids as string) + req.query.vs_currencies) as string);
+    if (hasCached) {
+      res.send(cache.get(req.url));
+      return;
+    } else {
+      res.sendStatus(400);
+    }
+  }
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import fallbackHandler, { healthCheck, iosURI, androidURI, nodeList } from "./ha
 import { entryRssHandler, authorRssHandler } from "./handlers/rss";
 import * as authApi from "./handlers/auth-api";
 import { cleanURL, authCheck, stripLastSlash } from "./util";
+import { coingeckoHandler } from "./handlers/coingecko.handler";
 
 const server = express();
 
@@ -83,7 +84,8 @@ server
 
   // Health check script for docker swarm
   .get("^/healthcheck.json$", healthCheck)
-
+  // CoinGecko market rate API
+  .get("^/coingecko/api/v3/simple/price$", coingeckoHandler)
   // For all others paths
   .get("*", fallbackHandler);
 

--- a/src/server/services/coingecko.api.ts
+++ b/src/server/services/coingecko.api.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+interface CoinGeckoApiResponse {
+  [key: string]: {
+    [vsKey: string]: number;
+  };
+}
+
+export async function getCGMarketApi(ids: string, vs: string): Promise<CoinGeckoApiResponse> {
+  const resp = await axios.get<CoinGeckoApiResponse>(
+    "https://api.coingecko.com/api/v3/simple/price",
+    {
+      params: {
+        ids,
+        vs_currencies: vs,
+        include_24hr_change: false
+      }
+    }
+  );
+  return resp.data;
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./amp-pages";
+export * from "./coingecko.api";


### PR DESCRIPTION
**What does this PR?**
Added coingecko proxy via server with a caching. Set cache etch time when coin gecko returns success response and get from cache each time when coin gecko returns failure response. If there are no cache and coin gecko is unreachable then returns 400.

**Where should the reviewer start?**
Just open `/market` and check USD value

**Steps to reproduce**
Just open `/market` and check USD value

**Issue number**

**Screenshots/Video**