### PR TITLE
Store last date range on Advanced search in localstorage

### DIFF
--- a/src/common/components/search-comment/index.tsx
+++ b/src/common/components/search-comment/index.tsx
@@ -10,6 +10,8 @@ import moment, { Moment } from "moment";
 
 import queryString from "query-string";
 
+import * as ls from "../../util/local-storage";
+
 import { Global } from "../../store/global/types";
 import { Account } from "../../store/accounts/types";
 
@@ -68,7 +70,7 @@ const pureState = (props: Props): State => {
 
   const q = qs.q as string;
   const sort = (qs.sort as SearchSort) || SearchSort.POPULARITY;
-  const date = (qs.date as DateOpt) || DateOpt.Y;
+  const date = (qs.date as DateOpt) || ls.get("recent_date");
   const hideLow = !(qs.hd && qs.hd === "0");
   const advanced = !!(qs.adv && qs.adv === "1");
   const sq = new SearchQuery(q);
@@ -129,6 +131,7 @@ export class SearchComment extends BaseComponent<Props, State> {
   };
 
   dateChanged = (e: React.ChangeEvent<typeof FormControl & HTMLInputElement>): void => {
+    ls.set("recent_date", e.target.value);
     this.stateSet({ date: e.target.value as DateOpt });
   };
 
@@ -333,7 +336,7 @@ export class SearchComment extends BaseComponent<Props, State> {
             </Form.Group>
             <Form.Group as={Col} sm="2" controlId="form-date">
               <Form.Label>{_t("search-comment.date")}</Form.Label>
-              <Form.Control as="select" value={date} onChange={this.dateChanged}>
+              <Form.Control as="select" value={ls.get("recent_date")} onChange={this.dateChanged}>
                 {Object.values(DateOpt).map((x) => (
                   <option value={x} key={x}>
                     {_t(`search-comment.date-${x}`)}


### PR DESCRIPTION
**What does this PR?**
Store last date range in local-storage. So for active user, their subsequent searches can use the stored date-range. 
Keep track of date range in advance searches. Subsequent searches will automatically use the stored date range.

**Steps to reproduce**
Search anything in search bar and select the date range of your own choice.
Do next search and observe, it will use the date range of previous selected date range.

**Issue number**
fixes #https://github.com/ecency/ecency-vision/issues/1043

**Screenshots/Video**


https://user-images.githubusercontent.com/106739598/200248087-e8a133fc-dd7c-41ed-86b9-87ec4e20f9fd.mp4

![Screenshot from 2022-11-07 12-21-43](https://user-images.githubusercontent.com/106739598/200248845-8cd87942-eaf3-4458-a142-263aab7ad7c3.png)
