### PR TITLE
promoted content in a separate page

### DIFF
--- a/src/common/components/entry-list/index.tsx
+++ b/src/common/components/entry-list/index.tsx
@@ -101,10 +101,13 @@ export class EntryListContent extends Component<Props, State> {
   }
 
   render() {
-    const { entries, promotedEntries, global, activeUser, loading } = this.props;
+    const { entries, promotedEntries, global, activeUser, loading, location } = this.props;
     const { filter, tag } = global;
     const { mutedUsers, loadingMutedUsers } = this.state;
     let dataToRender = entries;
+    if (location.pathname.includes("/promoted")) {
+      dataToRender = promotedEntries;
+    }
 
     let mutedList: string[] = [];
     if (mutedUsers && mutedUsers.length > 0 && activeUser && activeUser.username) {
@@ -146,15 +149,27 @@ export class EntryListContent extends Component<Props, State> {
 
               let isPostMuted =
                 (activeUser && activeUser.username && mutedList.includes(e.author)) || false;
-              l.push(
-                <EntryListItem
-                  key={`${e.author}-${e.permlink}`}
-                  {...this.props}
-                  entry={e}
-                  order={i}
-                  muted={isPostMuted}
-                />
-              );
+              if (location.pathname.includes("/promoted")) {
+                l.push(
+                  <EntryListItem
+                    key={`${e.author}-${e.permlink}`}
+                    {...Object.assign({}, { ...this.props }, { entry: e })}
+                    promoted={true}
+                    order={i}
+                    muted={isPostMuted}
+                  />
+                );
+              } else {
+                l.push(
+                  <EntryListItem
+                    key={`${e.author}-${e.permlink}`}
+                    {...this.props}
+                    entry={e}
+                    order={i}
+                    muted={isPostMuted}
+                  />
+                );
+              }
               return [...l];
             })}
           </>

--- a/src/common/pages/index.tsx
+++ b/src/common/pages/index.tsx
@@ -79,6 +79,7 @@ const Index = (props: PageProps) => {
       props.location?.pathname?.startsWith("/payout_comments") ||
       props.location?.pathname?.startsWith("/rising") ||
       props.location?.pathname?.startsWith("/purchase") ||
+      props.location?.pathname?.startsWith("/promoted") ||
       props.location?.pathname?.startsWith("/controversial");
 
     if (showLandingPage !== nextShowLandingPage) {

--- a/src/common/store/global/types.ts
+++ b/src/common/store/global/types.ts
@@ -20,7 +20,8 @@ export enum EntryFilter {
   payout_comments = "payout_comments",
   muted = "muted",
   controversial = "controversial",
-  rising = "rising"
+  rising = "rising",
+  promoted = "promoted"
 }
 
 export enum ProfileFilter {
@@ -46,7 +47,8 @@ export enum AllFilter {
   feed = "feed",
   no_reblog = "no_reblog",
   controversial = "controversial",
-  rising = "rising"
+  rising = "rising",
+  promoted = "promoted"
 }
 
 export interface Global {


### PR DESCRIPTION
**What does this PR?**
It will show the promoted post in a separate page
The URL of that page is "/promoted"

**Steps to reproduce**
Open the site and jut append the "/promoted" after the base URL.

**Issue number**
Fixes #https://github.com/ecency/ecency-vision/issues/1057

**Screenshots/Video**

https://user-images.githubusercontent.com/106739598/202379271-ef66130a-08fb-409d-98ea-9a0918681291.mp4
