### PR TITLE
Fixed swap form

### DIFF
--- a/src/common/components/market-swap-form/index.scss
+++ b/src/common/components/market-swap-form/index.scss
@@ -30,6 +30,10 @@
     @include themify(night) {
       color: $white;
     }
+
+    @media (max-width: $md-break) {
+      font-size: 6vw;
+    }
   }
 
   .swap-button-container {

--- a/src/common/components/market-swap-form/sign-by-key.tsx
+++ b/src/common/components/market-swap-form/sign-by-key.tsx
@@ -11,10 +11,18 @@ export interface Props {
   onKey: (key: PrivateKey) => void;
   onBack: () => void;
   signingKey: string;
+  isLoading: boolean;
   setSigningKey: (key: string) => void;
 }
 
-export const SignByKey = ({ activeUser, onKey, onBack, signingKey, setSigningKey }: Props) => {
+export const SignByKey = ({
+  activeUser,
+  onKey,
+  onBack,
+  signingKey,
+  setSigningKey,
+  isLoading
+}: Props) => {
   const [key, setKey] = useState("");
 
   useEffect(() => {
@@ -55,6 +63,7 @@ export const SignByKey = ({ activeUser, onKey, onBack, signingKey, setSigningKey
           autoFocus={true}
           autoComplete="off"
           placeholder={_t("key-or-hot.key-placeholder")}
+          disabled={isLoading}
           onChange={(e) => setKey(e.target.value)}
         />
       </InputGroup>
@@ -67,8 +76,9 @@ export const SignByKey = ({ activeUser, onKey, onBack, signingKey, setSigningKey
           variant="primary"
           className="py-3 mt-4 flex-1"
           onClick={() => generateKey()}
+          disabled={isLoading}
         >
-          {_t("market.swap")}
+          {isLoading ? _t("market.signing") : _t("market.sign")}
         </Button>
       </div>
     </div>

--- a/src/common/components/market-swap-form/sign-methods.tsx
+++ b/src/common/components/market-swap-form/sign-methods.tsx
@@ -52,6 +52,8 @@ export const SignMethods = ({
   setSigningKey
 }: Props) => {
   const [showSignByKey, setShowSignByKey] = useState(false);
+  const [isSignByKeyLoading, setIsSignByKeyLoading] = useState(false);
+  const [isSignByHsLoading, setIsSignByHsLoading] = useState(false);
 
   const onSwapByHs = async () => {
     swapByHs({
@@ -63,25 +65,35 @@ export const SignMethods = ({
   };
 
   const onSwapByKey = async (key: PrivateKey) => {
-    await swapAction((toAmount) =>
-      swapByKey(key, {
-        activeUser,
-        fromAsset: asset,
-        fromAmount,
-        toAmount
-      })
-    );
+    setIsSignByKeyLoading(true);
+    try {
+      await swapAction((toAmount) =>
+        swapByKey(key, {
+          activeUser,
+          fromAsset: asset,
+          fromAmount,
+          toAmount
+        })
+      );
+    } finally {
+      setIsSignByKeyLoading(false);
+    }
   };
 
   const onSwapByKc = async () => {
-    await swapAction((toAmount) =>
-      swapByKc({
-        activeUser,
-        fromAsset: asset,
-        fromAmount,
-        toAmount
-      })
-    );
+    setIsSignByHsLoading(true);
+    try {
+      await swapAction((toAmount) =>
+        swapByKc({
+          activeUser,
+          fromAsset: asset,
+          fromAmount,
+          toAmount
+        })
+      );
+    } finally {
+      setIsSignByHsLoading(false);
+    }
   };
 
   const swapAction = async (action: (toAmount: string) => Promise<any>) => {
@@ -106,6 +118,7 @@ export const SignMethods = ({
           signingKey={signingKey}
           setSigningKey={(key) => setSigningKey(key)}
           activeUser={activeUser}
+          isLoading={isSignByKeyLoading}
           onKey={(key) => onSwapByKey(key)}
           onBack={() => setShowSignByKey(false)}
         />
@@ -145,7 +158,9 @@ export const SignMethods = ({
               onClick={onSwapByKc}
             >
               <i className="sign-logo mr-3">{kcLogoSvg}</i>
-              {_t("market.swap-by", { method: "Keychain" })}
+              {isSignByHsLoading
+                ? _t("market.signing")
+                : _t("market.swap-by", { method: "Keychain" })}
             </Button>
           ) : (
             <></>

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -380,7 +380,7 @@
     "decimal-error": "Only {{decimals}} decimal digits allowed!",
     "from": "From",
     "to": "To",
-    "swap": "Sign",
+    "sign": "Sign",
     "swapping": "Swapping...",
     "continue": "Continue",
     "balance": "Balance",
@@ -399,7 +399,8 @@
     "auth-required-title": "Authorization required",
     "auth-required-desc": "You have to be authorized to swap own funds",
     "start-new-one": "Start new Swap",
-    "success-swap": "Successfully swapped!"
+    "success-swap": "Successfully swapped!",
+    "signing": "Signing.."
   },
   "list-style": {
     "title": "Toggle list style"


### PR DESCRIPTION
What does this PR?
Added dynamic font size for amount control in swap form
Fixed loading state for sign buttons

Steps to reproduce
1. Open swap market form and try to resize window -> enter pretty long amount -> amount value longer than input element(Fixed by adding dynamic font size based on viewport for device less than `md` breakpoint);
2. Try to sign with key or HS in the same frame