### PR TITLE
Keeping referral name is URL, later used or signup

### DIFF
--- a/src/common/components/entry-menu/index.tsx
+++ b/src/common/components/entry-menu/index.tsx
@@ -204,9 +204,13 @@ export class EntryMenu extends BaseComponent<Props, State> {
   };
 
   copyAddress = () => {
-    const { entry } = this.props;
-
-    const u = `https://ecency.com/${entry.category}/@${entry.author}/${entry.permlink}`;
+    const { entry, activeUser } = this.props;
+    let u;
+    if (activeUser?.username) {
+      u = `https://ecency.com/${entry.category}/@${entry.author}/${entry.permlink}?referral=${activeUser.username}`;
+    } else {
+      u = `https://ecency.com/${entry.category}/@${entry.author}/${entry.permlink}`;
+    }
     clipboard(u);
     success(_t("entry.address-copied"));
   };

--- a/src/common/components/navbar/index.tsx
+++ b/src/common/components/navbar/index.tsx
@@ -134,7 +134,7 @@ export class NavBar extends Component<Props, State> {
     // referral check / redirect
     const { location, history } = this.props;
     const qs = queryString.parse(location.search);
-    if (!location.pathname.startsWith("/signup") && qs.referral) {
+    if (location.pathname.startsWith("/signup") && qs.referral) {
       history.push(`/signup?referral=${qs.referral}`);
     }
     window

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -141,6 +141,11 @@ class EntryPage extends BaseComponent<Props, State> {
 
   componentDidMount() {
     this.ensureEntry();
+    const { history } = this.props;
+    if (history?.location.search.includes("?referral")) {
+      const userName = history.location.search.split("=")[1];
+      ls.set("referral", userName);
+    }
     this.fetchMutedUsers();
     const entry = this.getEntry();
 

--- a/src/common/pages/sign-up.tsx
+++ b/src/common/pages/sign-up.tsx
@@ -10,6 +10,8 @@ import { PageProps, pageMapDispatchToProps, pageMapStateToProps } from "./common
 
 import ReCAPTCHA from "react-google-recaptcha";
 
+import * as ls from "../../common/util/local-storage";
+
 import Meta from "../components/meta";
 import Theme from "../components/theme/index";
 import NavBar from "../components/navbar/index";
@@ -49,11 +51,17 @@ class SignUpPage extends Component<PageProps, State> {
   };
 
   componentDidMount() {
-    const { location } = this.props;
+    const { location, history } = this.props;
     const qs = queryString.parse(location.search);
     if (qs.referral) {
       const referral = qs.referral as string;
       this.setState({ referral, lockReferral: true });
+    } else if (ls.get("referral")) {
+      const referral = ls.get("referral");
+      history.push(`/signup?referral=${referral}`);
+      this.setState({ referral: referral });
+    } else {
+      history.push("/signup");
     }
   }
 
@@ -74,7 +82,6 @@ class SignUpPage extends Component<PageProps, State> {
 
   submit = () => {
     const { username, email, referral } = this.state;
-
     this.setState({ inProgress: true });
     signUp(username, email, referral)
       .then((resp) => {
@@ -87,6 +94,7 @@ class SignUpPage extends Component<PageProps, State> {
           error(resp.data.message);
         } else {
           this.setState({ done: true });
+          ls.remove("referral");
         }
       })
       .catch((err) => {


### PR DESCRIPTION
**What does this PR?**
When user try to share the post , it will append the username of active user in URL as optional parameter.
When any person open the link, it will extract the value of referral from the URL and store it in local storage.
When they click on sign up, the referral field is automatically detected by getting the value from the local stroage.
After signup, the referral name should be removed from the local storage.

**Steps to reproduce**

1. Copy the link of any post and open it in Incognito window. The URL of one post is pasted as an example:
http://localhost:3000/writing/@cheah/the-lies-of-diary-of-a-bomoh?referral=demo.com
2. Do some actions whatever you want like open another post, apply filter and other what you want.
3. When you click on signup , the referral field is automatically detected and filled by the username of the person who share the post to you. 


**Issue number** 

fixes #[1053](https://github.com/ecency/ecency-vision/issues/1053)

**Screenshots/Video**


https://user-images.githubusercontent.com/106739598/202697874-186e2f23-29c9-4f60-803c-a059a5de7b84.mp4

