### PR TITLE
google recaptcha hotfix

### DIFF
--- a/src/common/components/login/index.tsx
+++ b/src/common/components/login/index.tsx
@@ -402,7 +402,10 @@ export class Login extends BaseComponent<LoginProps, State> {
       error(_t("login.error-fields-required"));
       return;
     }
-
+    if (!this.state.isVerified) {
+      error(_t("login.checkbox-checked-required"));
+      return;
+    }
     // Warn if the code is a public key
     try {
       PublicKey.fromString(key);

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -156,6 +156,7 @@
     "login-info-1": "We don't store your private keys.",
     "login-info-2": "More info",
     "error-fields-required": "Please enter username and private key",
+    "captcha-check-required": "Please verify if you are a human",
     "error-public-key": "You entered a public key. Password/WIF required",
     "error-user-fetch": "User data could not be fetched",
     "error-user-not-found": "User does not exist",

--- a/src/common/pages/sign-up.tsx
+++ b/src/common/pages/sign-up.tsx
@@ -79,6 +79,10 @@ class SignUpPage extends Component<PageProps, State> {
     signUp(username, email, referral)
       .then((resp) => {
         this.setState({ inProgress: false });
+        if (!this.state.isVerified) {
+          error(_t("login.checkbox-checked-required"));
+          return;
+        }
         if (resp && resp.data && resp.data.code) {
           error(resp.data.message);
         } else {


### PR DESCRIPTION
**What does this PR?**
This is not allowed the user to logged in until or unless it verify the google recaptcha.

**Steps to reproduce**
Autofil the email and password and press enter to proceed further. it will not allow you to logged in until you verify the google recaptcha.

**Issue number**
fixes #[1047](https://github.com/ecency/ecency-vision/issues/1047)

**Screenshots/Video**