### PR TITLE
Add Brazilian Real (BRL) to currencies

### DIFF
--- a/src/common/constants/currencies.json
+++ b/src/common/constants/currencies.json
@@ -16,6 +16,10 @@
     "name": "EUR"
   },
   {
+    "id": "brl",
+    "name": "BRL"
+  },
+  {
     "id": "rub",
     "name": "RUB"
   },


### PR DESCRIPTION
I tested locally and it works. Brazilian users will be glad to see our currency added to Ecency.