### PR TITLE
Store post and comment vote percentages

### DIFF
--- a/src/common/components/discussion/index.tsx
+++ b/src/common/components/discussion/index.tsx
@@ -418,7 +418,8 @@ export const Item = (props: ItemProps) => {
                     {EntryVoteBtn({
                       ...props,
                       entry,
-                      afterVote: afterVote
+                      afterVote: afterVote,
+                      isPostSlider: false
                     })}
                     {EntryPayout({
                       ...props,

--- a/src/common/components/entry-list-item/index.tsx
+++ b/src/common/components/entry-list-item/index.tsx
@@ -516,6 +516,7 @@ export default class EntryListItem extends Component<Props, State> {
           <div className="item-controls">
             {EntryVoteBtn({
               ...this.props,
+              isPostSlider: true,
               afterVote: this.afterVote
             })}
             {EntryPayout({

--- a/src/common/helper/__snapshots__/posting.spec.ts.snap
+++ b/src/common/helper/__snapshots__/posting.spec.ts.snap
@@ -21,6 +21,9 @@ Object {
   "image": Array [
     "http://www.xx.com/a.png",
   ],
+  "thumbnails": Array [
+    "http://www.xx.com/a.png",
+  ],
   "users": Array [
     "lorem",
     "ipsum",
@@ -36,6 +39,10 @@ Object {
   ],
   "links": Array [
     "http://www.google.com/foo/bar",
+  ],
+  "thumbnails": Array [
+    "http://www.xx.com/a.png",
+    "https://img.esteem.ws/h74zrad2fh.jpg",
   ],
   "users": Array [
     "lorem",

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -1172,6 +1172,7 @@ class EntryPage extends BaseComponent<Props, State> {
                       <div className="entry-controls" ref={setRef}>
                         {EntryVoteBtn({
                           ...this.props,
+                          isPostSlider: true,
                           entry,
                           afterVote: this.afterVote
                         })}


### PR DESCRIPTION
**What does this PR?**

It will store the last vote percentage of post and comment in local storage.
If there is previously stored value in local storage , it will get the value from local storage and display the previous voted value.
If there is no value in local storage means user open the voting slider first time, it will display the default value in the slider.


**Steps to reproduce**

1. Open the voting slider of any post and vote to that post or just move the slider to change the value of slider. it will store the updated value of slider in local storage.
2. When you open the slider of any post next time, it will show and  set the previous stored value.
3. Same is the case with comment-voting-slider.But post-voting-slider value and comment-voting-slider value stored separately and  independent to each other.
4. Stored the value of slider in both **Up** and **Down** case.


**Issue number** 

fixes #[1048](https://github.com/ecency/ecency-vision/issues/1048)


**Screenshots/Video**

https://user-images.githubusercontent.com/106739598/205293384-87226905-d016-405f-94e4-9034421292a9.mp4


