### PR TITLE
Undelegate button should ask for confirmation before moving forwarding with it.

### DIFF
--- a/src/common/components/delegated-vesting/index.tsx
+++ b/src/common/components/delegated-vesting/index.tsx
@@ -166,6 +166,7 @@ export class List extends BaseComponent<Props, State> {
                 activeUser && activeUser.username === account.name
                   ? KeyOrHotDialog({
                       ...this.props,
+                      popOver: true,
                       activeUser: activeUser,
                       children: (
                         <a href="#" className="undelegate">

--- a/src/common/components/key-or-hot-dialog/index.tsx
+++ b/src/common/components/key-or-hot-dialog/index.tsx
@@ -9,10 +9,13 @@ import { ActiveUser } from "../../store/active-user/types";
 
 import KeyOrHot from "../key-or-hot";
 
+import PopoverConfirm from "../popover-confirm";
+
 interface Props {
   global: Global;
   activeUser: ActiveUser;
   signingKey: string;
+  popOver?: boolean;
   setSigningKey: (key: string) => void;
   children: JSX.Element;
   onKey: (key: PrivateKey) => void;
@@ -26,6 +29,8 @@ interface State {
 }
 
 export class KeyOrHotDialog extends Component<Props, State> {
+  static defaultProps: { popOver: boolean };
+
   state: State = {
     keyDialog: false
   };
@@ -39,19 +44,31 @@ export class KeyOrHotDialog extends Component<Props, State> {
   };
 
   render() {
-    const { children, onKey, onHot, onKc } = this.props;
+    const { children, onKey, onHot, onKc, popOver } = this.props;
     const { keyDialog } = this.state;
 
     const newChildren = React.cloneElement(children, {
       onClick: (e: React.MouseEvent) => {
         e.preventDefault();
-        this.toggleKeyDialog();
+        return !popOver && this.toggleKeyDialog();
       }
     });
 
     return (
       <>
-        {newChildren}
+        {popOver ? (
+          <div className="main">
+            <PopoverConfirm
+              placement="left"
+              trigger="click"
+              onConfirm={() => this.toggleKeyDialog()}
+            >
+              <div onClick={(e) => e.stopPropagation()}>{newChildren}</div>
+            </PopoverConfirm>
+          </div>
+        ) : (
+          newChildren
+        )}
 
         {keyDialog && (
           <Modal
@@ -92,11 +109,16 @@ export class KeyOrHotDialog extends Component<Props, State> {
   }
 }
 
+KeyOrHotDialog.defaultProps = {
+  popOver: false
+};
+
 export default (p: Props) => {
   const props = {
     global: p.global,
     activeUser: p.activeUser,
     signingKey: p.signingKey,
+    popOver: p.popOver,
     setSigningKey: p.setSigningKey,
     children: p.children,
     onKey: p.onKey,


### PR DESCRIPTION
**What does this PR?**

Show the confirmation model before undelegating.

**Steps to reproduce**

1. Open wallet and click on undelegate. 
2. It will open the confirmation model. if user clicks on "confirm" , it will show the next Dialog.
3. If user clicks in "cancel", it  hides the confirmation modal and will not move forward.

**Issue number** 

fixes #[1160](https://github.com/ecency/ecency-vision/issues/1160)

**Screenshot / Video**


https://user-images.githubusercontent.com/106739598/209121113-9172ca91-b6ea-4a69-bc3c-93760153d978.mp4

