### PR TITLE
proposal votes pagination

### DIFF
--- a/src/common/api/hive.ts
+++ b/src/common/api/hive.ts
@@ -411,8 +411,8 @@ export interface ProposalVote {
 
 export const getProposalVotes = (
   proposalId: number,
-  voter: string = "",
-  limit: number = 300
+  voter: string,
+  limit: number
 ): Promise<ProposalVote[]> =>
   client
     .call("condenser_api", "list_proposal_votes", [[proposalId, voter], limit, "by_proposal_voter"])

--- a/src/common/components/proposal-list-item/index.tsx
+++ b/src/common/components/proposal-list-item/index.tsx
@@ -232,7 +232,7 @@ export class ProposalListItem extends Component<Props, State> {
         {proposal.id === isReturnProposalId && (
           <div className="return-proposal">{_t("proposals.return-description")}</div>
         )}
-        {votes && <ProposalVotes {...this.props} onHide={this.toggleVotes} />}
+        {votes && <ProposalVotes {...this.props} votes={strVotes} onHide={this.toggleVotes} />}
       </div>
     );
   }

--- a/src/common/components/proposal-list-item/index.tsx
+++ b/src/common/components/proposal-list-item/index.tsx
@@ -232,7 +232,7 @@ export class ProposalListItem extends Component<Props, State> {
         {proposal.id === isReturnProposalId && (
           <div className="return-proposal">{_t("proposals.return-description")}</div>
         )}
-        {votes && <ProposalVotes {...this.props} votes={strVotes} onHide={this.toggleVotes} />}
+        {votes && <ProposalVotes {...this.props} onHide={this.toggleVotes} />}
       </div>
     );
   }

--- a/src/common/components/proposal-votes/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/proposal-votes/__snapshots__/index.spec.tsx.snap
@@ -1,105 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`(1) Default render. 1`] = `
-<div
-  className="voters-list"
->
+Array [
   <div
-    className="list-body"
+    className="voters-list"
   >
     <div
-      className="list-item"
+      className="list-body"
     >
       <div
-        className="item-main"
+        className="user-info"
       >
-        <a
-          href="/@foo"
-          onClick={[Function]}
-        >
-          <span
-            className="user-avatar small"
-            style={
-              Object {
-                "backgroundImage": "url(https://images.ecency.com/u/foo/avatar/small)",
-              }
-            }
-          />
-        </a>
-        <div
-          className="item-info"
-        >
-          <a
-            className="item-name notransalte"
-            href="/@foo"
-            onClick={[Function]}
-          >
-            foo
-          </a>
-          <span
-            className="item-reputation"
-          >
-            77
-          </span>
-        </div>
-      </div>
-      <div
-        className="item-extra"
-      >
-        <span>
-          126,434.601 HP
-        </span>
+        No results found
       </div>
     </div>
+  </div>,
+  <div
+    className="list-tools"
+  >
     <div
-      className="list-item"
+      className="pages"
+    />
+    <div
+      className="sorter"
     >
-      <div
-        className="item-main"
+      <span
+        className="label"
       >
-        <a
-          href="/@bar"
-          onClick={[Function]}
-        >
-          <span
-            className="user-avatar small"
-            style={
-              Object {
-                "backgroundImage": "url(https://images.ecency.com/u/bar/avatar/small)",
-              }
-            }
-          />
-        </a>
-        <div
-          className="item-info"
-        >
-          <a
-            className="item-name notransalte"
-            href="/@bar"
-            onClick={[Function]}
-          >
-            bar
-          </a>
-          <span
-            className="item-reputation"
-          >
-            62
-          </span>
-        </div>
-      </div>
-      <div
-        className="item-extra"
+        Sort
+      </span>
+      <select
+        className="form-control"
+        onChange={[Function]}
+        value="hp"
       >
-        <span>
-          3,236.532 HP
-        </span>
-         + 
-        <span>
-          5,492.800 HP
-           (proxy) 
-        </span>
-      </div>
+        <option
+          value="reputation"
+        >
+          Reputation
+        </option>
+        <option
+          value="hp"
+        >
+          Hive Power
+        </option>
+      </select>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/src/common/components/proposal-votes/_index.scss
+++ b/src/common/components/proposal-votes/_index.scss
@@ -1,10 +1,42 @@
 .proposal-votes-dialog {
+  .modal-content {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+  
   .modal-body {
-    height: 500px;
-    overflow: auto;
-
+    padding: 0 0 10px 0;
+    
     .voters-list {
       @include user-grid-list(1, 1, 2);
+      margin-bottom: 20px;
+      height: 440px;
+      overflow: auto;
+
+    }
+  }
+}
+
+.list-tools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: column-reverse;
+
+  @media (min-width: $lg-break) {
+    flex-direction: row;
+  }
+
+  .sorter {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+    @media (min-width: $lg-break) {
+      margin-bottom: 0;
+    }
+
+    .label {
+      margin-right: 4px;
     }
   }
 }

--- a/src/common/components/proposal-votes/_index.scss
+++ b/src/common/components/proposal-votes/_index.scss
@@ -40,3 +40,6 @@
     }
   }
 }
+.user-info {
+  margin: 1rem 0 0 1rem;
+}

--- a/src/common/components/proposal-votes/index.spec.tsx
+++ b/src/common/components/proposal-votes/index.spec.tsx
@@ -51,7 +51,9 @@ const defProps = {
   global: globalInstance,
   dynamicProps: dynamicPropsIntance1,
   proposal: proposalInstance,
+  searchText: " ",
   addAccount: () => {},
+  getVotesCount: () => {},
   onHide: () => {}
 };
 

--- a/src/common/components/proposal-votes/index.tsx
+++ b/src/common/components/proposal-votes/index.tsx
@@ -117,13 +117,13 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
     const { voter, limit } = this.state;
     getProposalVotes(proposal.id, voter, limit)
       .then((votes) => {
-        getVotesCount(votes.length);
         this.setState({ voter: votes[votes.length - 1].voter, lastDataLength: votes.length });
         const usernames = [...new Set(votes.map((x) => x.voter))]; // duplicate records come in some way.
 
         return getAccounts(usernames);
       })
       .then((resp) => {
+        getVotesCount(resp.length);
         let voters: Voter[] = resp
           .map((account) => {
             const hp = (parseAsset(account.vesting_shares).amount * hivePerMVests) / 1e6;
@@ -294,6 +294,7 @@ export class ProposalVotes extends Component<ProposalVotesProps, ProposalVotesSt
   render() {
     const { proposal, onHide } = this.props;
     const { searchText, voteCount } = this.state;
+    const modelTitle = voteCount % 1000 ? voteCount + " " : voteCount + "+" + " ";
     return (
       <Modal
         onHide={onHide}
@@ -305,7 +306,7 @@ export class ProposalVotes extends Component<ProposalVotesProps, ProposalVotesSt
       >
         <Modal.Header closeButton={true} className="align-items-center px-0">
           <Modal.Title>
-            {voteCount + " " + _t("proposals.votes-dialog-title", { n: proposal.id })}
+            {modelTitle + _t("proposals.votes-dialog-title", { n: proposal.id })}
           </Modal.Title>
         </Modal.Header>
         <Form.Group className="w-100 mb-3">

--- a/src/common/components/proposal-votes/index.tsx
+++ b/src/common/components/proposal-votes/index.tsx
@@ -72,9 +72,13 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
     this.load();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const { voters } = this.state;
     if (prevProps.searchText !== this.props.searchText) {
       this.search();
+    }
+    if (prevState.voters !== voters) {
+      this.setState({ noOfPages: Math.ceil(voters.length / 12) });
     }
   }
 
@@ -150,8 +154,7 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
           {
             voters,
             originalVoters: uniqueOriginalVoters,
-            loading: false,
-            noOfPages: Math.ceil(voters.length / 12)
+            loading: false
           },
           this.search
         );

--- a/src/common/components/proposal-votes/index.tsx
+++ b/src/common/components/proposal-votes/index.tsx
@@ -79,6 +79,7 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
   }
 
   search = () => {
+    const { originalVoters } = this.state;
     if (this.props.searchText) {
       this.setState(
         {
@@ -89,6 +90,8 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
         },
         this.searchCallback
       );
+    } else {
+      this.setState({ voters: originalVoters, loading: false });
     }
   };
 

--- a/src/common/components/proposal-votes/index.tsx
+++ b/src/common/components/proposal-votes/index.tsx
@@ -49,7 +49,7 @@ interface State {
   voters: Voter[];
   originalVoters: Voter[];
   sort: SortOption;
-  noOfPages: number;
+  pageCount: number;
   voter: string;
   lastDataLength: number;
   limit: number;
@@ -62,7 +62,7 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
     voters: [],
     originalVoters: [],
     sort: "hp",
-    noOfPages: 0,
+    pageCount: 0,
     voter: "",
     lastDataLength: 0,
     limit: 1000
@@ -78,7 +78,7 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
       this.search();
     }
     if (prevState.voters !== voters) {
-      this.setState({ noOfPages: Math.ceil(voters.length / 12) });
+      this.setState({ pageCount: Math.ceil(voters.length / 12) });
     }
   }
 
@@ -162,8 +162,8 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
   };
 
   handlePageChange = () => {
-    const { noOfPages, page, lastDataLength, limit } = this.state;
-    if (page === noOfPages && lastDataLength === limit) {
+    const { pageCount, page, lastDataLength, limit } = this.state;
+    if (page === pageCount && lastDataLength === limit) {
       this.load();
     }
   };
@@ -179,10 +179,9 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
       .sort((a, b) => {
         const keyA = a[sort]!;
         const keyB = b[sort]!;
-
         if (keyA > keyB) return -1;
-        if (keyA < keyB) return 1;
-        return 0;
+        else if (keyA < keyB) return 1;
+        else return 0;
       })
       .slice(start, end);
 
@@ -192,49 +191,51 @@ export class ProposalVotesDetail extends BaseComponent<Props, State> {
 
         <div className="voters-list">
           <div className="list-body">
-            {sliced && sliced.length > 0
-              ? sliced.map((x) => {
-                  const strHp = numeral(x.hp).format("0.00,");
-                  const strProxyHp = numeral(x.proxyHp).format("0.00,");
+            {sliced && sliced.length > 0 ? (
+              sliced.map((x) => {
+                const strHp = numeral(x.hp).format("0.00,");
+                const strProxyHp = numeral(x.proxyHp).format("0.00,");
 
-                  return (
-                    <div className="list-item" key={x.name}>
-                      <div className="item-main">
+                return (
+                  <div className="list-item" key={x.name}>
+                    <div className="item-main">
+                      {ProfileLink({
+                        ...this.props,
+                        username: x.name,
+                        children: (
+                          <>{UserAvatar({ ...this.props, username: x.name, size: "small" })}</>
+                        )
+                      })}
+
+                      <div className="item-info">
                         {ProfileLink({
                           ...this.props,
                           username: x.name,
-                          children: (
-                            <>{UserAvatar({ ...this.props, username: x.name, size: "small" })}</>
-                          )
+                          children: <a className="item-name notransalte">{x.name}</a>
                         })}
-
-                        <div className="item-info">
-                          {ProfileLink({
-                            ...this.props,
-                            username: x.name,
-                            children: <a className="item-name notransalte">{x.name}</a>
-                          })}
-                          <span className="item-reputation">{accountReputation(x.reputation)}</span>
-                        </div>
-                      </div>
-                      <div className="item-extra">
-                        <span>{`${strHp} HP`}</span>
-                        {x.proxyHp > 0 && (
-                          <>
-                            {" + "}
-                            <span>
-                              {`${strProxyHp} HP`}
-                              {" (proxy) "}
-                            </span>
-                          </>
-                        )}
+                        <span className="item-reputation">{accountReputation(x.reputation)}</span>
                       </div>
                     </div>
-                  );
-                })
-              : loading
-              ? _t("proposals.searching")
-              : _t("proposals.no-results")}
+                    <div className="item-extra">
+                      <span>{`${strHp} HP`}</span>
+                      {x.proxyHp > 0 && (
+                        <>
+                          {" + "}
+                          <span>
+                            {`${strProxyHp} HP`}
+                            {" (proxy) "}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            ) : (
+              <div className="user-info">
+                {loading ? _t("proposals.searching") : _t("proposals.no-results")}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -1332,7 +1332,13 @@
     "see-all": "see all proposals",
     "daily-funded": "daily funded",
     "daily-budget": "daily budget",
-    "total-budget": "total budget"
+    "total-budget": "total budget",
+    "search-placeholder": "Search",
+    "sort": "Sort",
+    "sort-reputation": "Reputation",
+    "sort-hp": "Hive Power",
+    "no-results": "No results found",
+    "searching": "Searching"
   },
   "gallery": {
     "title": "Gallery",


### PR DESCRIPTION
**What does this PR?**

Shows the HP of that proposal in the modal header.
Creates a search bar below the modal header to search the particular voter.
Shows the pagination and sorting option below the modal body.
when user reaches to the last page of pagination , it will fetches the next limited records until all the records fetched.
When user searches any voter , if that voter is not present in current list , it will fetch the next record and find that user until all the records fetched.

**Steps to reproduce**

1. Click on the "Votes" of any proposal , it will open the modal.
2. Search any record by typing name of voter in the search bar.If it is present in the current list , it will display that record 
    otherwise it will fetch the next records until all records been fetched.
3. User can jump into the last and first page by clicking on the last and first page icon.

**Issue number** 

Fixes #1161

**Screenshot / Video**



https://user-images.githubusercontent.com/106739598/210304914-d79b1361-48d9-434c-abe9-7aedfed992c0.mp4



