### PR TITLE
Moveout clipboard events

### DIFF
--- a/src/common/components/editor-toolbar/index.tsx
+++ b/src/common/components/editor-toolbar/index.tsx
@@ -69,11 +69,7 @@ export const detectEvent = (eventType: string) => {
 };
 
 export const toolbarEventListener = (event: Event, eventType: string) => {
-  const detail = {
-    event: event,
-    eventType: eventType
-  };
-  const ev = new CustomEvent("customToolbarEvent", { detail });
+  const ev = new CustomEvent("customToolbarEvent", { detail: { event, eventType } });
   window.dispatchEvent(ev);
 };
 

--- a/src/common/components/editor-toolbar/index.tsx
+++ b/src/common/components/editor-toolbar/index.tsx
@@ -73,7 +73,7 @@ export const toolbarEventListener = (event: Event, eventType: string) => {
     event: event,
     eventType: eventType
   };
-  const ev = new CustomEvent("eventListener", { detail });
+  const ev = new CustomEvent("customToolbarEvent", { detail });
   window.dispatchEvent(ev);
 };
 
@@ -151,7 +151,7 @@ export class EditorToolbar extends Component<Props> {
     window.addEventListener("codeBlock", this.code);
     window.addEventListener("blockquote", this.quote);
     window.addEventListener("image", this.toggleImage);
-    window.addEventListener("eventListener", this.onEventListener);
+    window.addEventListener("customToolbarEvent", this.handleCustomToolbarEvent);
   }
 
   componentWillUnmount() {
@@ -162,10 +162,10 @@ export class EditorToolbar extends Component<Props> {
     window.removeEventListener("codeBlock", this.code);
     window.removeEventListener("blockquote", this.quote);
     window.removeEventListener("image", this.toggleImage);
-    window.removeEventListener("eventListener", this.onEventListener);
+    window.removeEventListener("customToolbarEvent", this.handleCustomToolbarEvent);
   }
 
-  onEventListener = (e: Event) => {
+  handleCustomToolbarEvent = (e: Event) => {
     const detail = (e as CustomEvent).detail;
     switch (detail.eventType) {
       case "paste":
@@ -177,8 +177,6 @@ export class EditorToolbar extends Component<Props> {
       case "drop":
         this.drop(detail.event);
         break;
-      default:
-      // code block
     }
   };
 

--- a/src/common/components/editor-toolbar/index.tsx
+++ b/src/common/components/editor-toolbar/index.tsx
@@ -68,6 +68,15 @@ export const detectEvent = (eventType: string) => {
   window.dispatchEvent(ev);
 };
 
+export const toolbarEventListener = (event: Event, eventType: string) => {
+  const detail = {
+    event: event,
+    eventType: eventType
+  };
+  const ev = new CustomEvent("eventListener", { detail });
+  window.dispatchEvent(ev);
+};
+
 export class EditorToolbar extends Component<Props> {
   state: State = {
     gallery: false,
@@ -142,23 +151,10 @@ export class EditorToolbar extends Component<Props> {
     window.addEventListener("codeBlock", this.code);
     window.addEventListener("blockquote", this.quote);
     window.addEventListener("image", this.toggleImage);
-    setTimeout(() => {
-      const el = this.getTargetEl();
-      if (el) {
-        el.addEventListener("dragover", this.onDragOver);
-        el.addEventListener("drop", this.drop);
-        el.addEventListener("paste", this.onPaste);
-      }
-    }, 0);
+    window.addEventListener("eventListener", this.onEventListener);
   }
 
   componentWillUnmount() {
-    const el = this.getTargetEl();
-    if (el) {
-      el.removeEventListener("dragover", this.onDragOver);
-      el.removeEventListener("drop", this.drop);
-      el.removeEventListener("paste", this.onPaste);
-    }
     window.removeEventListener("bold", this.bold);
     window.removeEventListener("italic", this.italic);
     window.removeEventListener("table", this.table);
@@ -166,7 +162,25 @@ export class EditorToolbar extends Component<Props> {
     window.removeEventListener("codeBlock", this.code);
     window.removeEventListener("blockquote", this.quote);
     window.removeEventListener("image", this.toggleImage);
+    window.removeEventListener("eventListener", this.onEventListener);
   }
+
+  onEventListener = (e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    switch (detail.eventType) {
+      case "paste":
+        this.onPaste(detail.event);
+        break;
+      case "dragover":
+        this.onDragOver(detail.event);
+        break;
+      case "drop":
+        this.drop(detail.event);
+        break;
+      default:
+      // code block
+    }
+  };
 
   getTargetEl = (): HTMLInputElement | null => {
     const holder = this.holder.current;

--- a/src/common/pages/submit.tsx
+++ b/src/common/pages/submit.tsx
@@ -244,18 +244,47 @@ class SubmitPage extends BaseComponent<Props, State> {
       this.detectDraft().then();
     }
   }
+
+  componentWillUnmount(): void {
+    this.removeToolbarEventListners();
+  }
+
   addToolbarEventListners = () => {
     if (this.holder) {
       const el = this.holder?.current;
 
       if (el) {
-        const events = ["dragover", "drop", "paste"];
-        events.map(function (e: string) {
-          el.addEventListener(e, (event) => toolbarEventListener(event, e));
-        });
+        el.addEventListener("paste", this.handlePaste);
+        el.addEventListener("dragover", this.handleDragover);
+        el.addEventListener("drop", this.handleDrop);
       }
     }
   };
+
+  removeToolbarEventListners = () => {
+    if (this.holder) {
+      const el = this.holder?.current;
+
+      if (el) {
+        el.removeEventListener("paste", this.handlePaste);
+        el.removeEventListener("dragover", this.handleDragover);
+        el.removeEventListener("drop", this.handleDrop);
+      }
+    }
+  };
+
+  handlePaste = (event: Event): void => {
+    toolbarEventListener(event, "paste");
+  };
+
+  handleDragover = (event: Event): void => {
+    toolbarEventListener(event, "dragover");
+  };
+
+  handleDrop = (event: Event): void => {
+    toolbarEventListener(event, "drop");
+  };
+
   handleValidForm = (value: boolean) => {
     this.setState({ disabled: value });
   };

--- a/src/common/pages/submit.tsx
+++ b/src/common/pages/submit.tsx
@@ -249,14 +249,9 @@ class SubmitPage extends BaseComponent<Props, State> {
       const el = this.holder?.current;
 
       if (el) {
-        el.addEventListener("dragover", function (event) {
-          toolbarEventListener(event, "dragover");
-        });
-        el.addEventListener("drop", function (event) {
-          toolbarEventListener(event, "drop");
-        });
-        el.addEventListener("paste", function (event) {
-          toolbarEventListener(event, "paste");
+        const events = ["dragover", "drop", "paste"];
+        events.map(function (e: string) {
+          el.addEventListener(e, (event) => toolbarEventListener(event, e));
         });
       }
     }

--- a/src/common/pages/submit.tsx
+++ b/src/common/pages/submit.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Ref } from "react";
 
 import { connect } from "react-redux";
 
@@ -42,7 +42,7 @@ import { makePath as makePathEntry } from "../components/entry-link";
 import MdHandler from "../components/md-handler";
 import BeneficiaryEditor from "../components/beneficiary-editor";
 import PostScheduler from "../components/post-scheduler";
-import { detectEvent } from "../components/editor-toolbar";
+import { detectEvent, toolbarEventListener } from "../components/editor-toolbar";
 
 import {
   addDraft,
@@ -171,6 +171,11 @@ interface State extends PostBase, Advanced {
 }
 
 class SubmitPage extends BaseComponent<Props, State> {
+  holder: React.RefObject<HTMLDivElement>;
+  constructor(props: Props) {
+    super(props);
+    this.holder = React.createRef();
+  }
   state: State = {
     title: "",
     tags: [],
@@ -215,6 +220,8 @@ class SubmitPage extends BaseComponent<Props, State> {
     if (selectedThumbnail && selectedThumbnail.length > 0) {
       this.selectThumbnails(selectedThumbnail);
     }
+
+    this.addToolbarEventListners();
   };
 
   componentDidUpdate(prevProps: Readonly<Props>) {
@@ -237,7 +244,23 @@ class SubmitPage extends BaseComponent<Props, State> {
       this.detectDraft().then();
     }
   }
+  addToolbarEventListners = () => {
+    if (this.holder) {
+      const el = this.holder?.current;
 
+      if (el) {
+        el.addEventListener("dragover", function (event) {
+          toolbarEventListener(event, "dragover");
+        });
+        el.addEventListener("drop", function (event) {
+          toolbarEventListener(event, "drop");
+        });
+        el.addEventListener("paste", function (event) {
+          toolbarEventListener(event, "paste");
+        });
+      }
+    }
+  };
   handleValidForm = (value: boolean) => {
     this.setState({ disabled: value });
   };
@@ -970,7 +993,7 @@ class SubmitPage extends BaseComponent<Props, State> {
                 onValid: this.handleValidForm
               })}
             </div>
-            <div className="body-input" onKeyDown={this.handleShortcuts}>
+            <div className="body-input" onKeyDown={this.handleShortcuts} ref={this.holder}>
               <TextareaAutocomplete
                 acceptCharset="UTF-8"
                 global={this.props.global}


### PR DESCRIPTION
**What does this PR?**

Moveout the clipboard events from editor-toolbar-component to parent component (submit page).

**Steps to reproduce**

1. Open "create a post" page and paste something in the text area.
2. Dragover and drop the text in the textarea to verify that all the events working properly or not.

**Issue number** 

fixes #[1061](https://github.com/ecency/ecency-vision/issues/1061)

**Screenshot / Video**

https://user-images.githubusercontent.com/106739598/210374717-f79dc445-7136-4964-9cd4-4d67dde9613d.mp4

