### PR TITLE
Voting slider bug

### DIFF
--- a/src/common/components/entry-vote-btn/index.tsx
+++ b/src/common/components/entry-vote-btn/index.tsx
@@ -500,23 +500,28 @@ export class EntryVoteBtn extends BaseComponent<Props, State> {
 
   getPreviousVote = async () => {
     const { activeUser, entry } = this.props;
-    const { upVoted } = this.isVoted();
+    const { upVoted, downVoted } = this.isVoted();
     let previousVote;
     if (!activeUser) {
       return null;
     }
 
-    let username = this.props.activeUser?.username! + "-" + this.props.entry.post_id;
-    let type = upVoted ? "up" : "down";
-    let sessValue = ss.get(`vote-value-${type}-${username}`, null);
-    if (sessValue !== null) {
-      return sessValue;
-    }
+    if (upVoted || downVoted) {
+      let username = this.props.activeUser?.username! + "-" + this.props.entry.post_id;
+      let type = upVoted ? "up" : "down";
+      let sessValue = ss.get(`vote-value-${type}-${username}`, null);
 
-    const retData = await getActiveVotes(entry.author, entry.permlink);
-    let votes = prepareVotes(entry, retData);
-    previousVote = votes.find((x) => x.voter === activeUser.username);
-    return previousVote === undefined ? null : previousVote.percent;
+      if (sessValue !== null) {
+        return sessValue;
+      }
+
+      const retData = await getActiveVotes(entry.author, entry.permlink);
+      let votes = prepareVotes(entry, retData);
+      previousVote = votes.find((x) => x.voter === activeUser.username);
+      return previousVote === undefined ? null : previousVote.percent;
+    } else {
+      return null;
+    }
   };
 
   render() {

--- a/src/common/components/entry-vote-slider/index.tsx
+++ b/src/common/components/entry-vote-slider/index.tsx
@@ -30,6 +30,7 @@ const VotingSlider = (props: Props) => {
   );
 
   useEffect(() => {
+    setSliderVal(props.value);
     const addEventListnersOnMount = (): void => {
       window.addEventListener("resize", _wondowResizeHandler, true);
     };

--- a/src/common/components/entry-vote-slider/index.tsx
+++ b/src/common/components/entry-vote-slider/index.tsx
@@ -7,7 +7,6 @@ import React, {
   MouseEventHandler,
   TouchEventHandler
 } from "react";
-import { setWithdrawVestingRouteHot } from "../../api/operations";
 
 interface Props {
   value: number;
@@ -24,13 +23,11 @@ const VotingSlider = (props: Props) => {
   const [sliderVal, setSliderVal] = useState(Math.abs(props.value));
   const tenOptions = [10, 20, 30, 40, 50, 60, 70, 80, 90];
   const fiveOptions = [25, 50, 75];
-
   const [sliderOptions, setSliderOptions] = useState(
     window.innerWidth > 1600 ? tenOptions : fiveOptions
   );
 
   useEffect(() => {
-    setSliderVal(props.value);
     const addEventListnersOnMount = (): void => {
       window.addEventListener("resize", _wondowResizeHandler, true);
     };

--- a/src/common/components/entry-votes/index.tsx
+++ b/src/common/components/entry-votes/index.tsx
@@ -154,7 +154,6 @@ export class EntryVotesDetail extends BaseComponent<DetailProps, DetailState> {
         return 0;
       })
       .slice(start, end);
-    // console.log(votes);
 
     return (
       <>
@@ -256,7 +255,6 @@ export class EntryVotes extends Component<Props, State> {
     const { entry } = this.props;
     const { visible, searchText, searchTextDisabled } = this.state;
     const totalVotes = (entry.active_votes && entry.active_votes.length) || entry.total_votes;
-    // console.log("Entry Votes Props", this.props);
 
     const title =
       totalVotes === 0

--- a/src/common/components/entry-votes/index.tsx
+++ b/src/common/components/entry-votes/index.tsx
@@ -154,6 +154,7 @@ export class EntryVotesDetail extends BaseComponent<DetailProps, DetailState> {
         return 0;
       })
       .slice(start, end);
+    // console.log(votes);
 
     return (
       <>
@@ -255,6 +256,7 @@ export class EntryVotes extends Component<Props, State> {
     const { entry } = this.props;
     const { visible, searchText, searchTextDisabled } = this.state;
     const totalVotes = (entry.active_votes && entry.active_votes.length) || entry.total_votes;
+    // console.log("Entry Votes Props", this.props);
 
     const title =
       totalVotes === 0


### PR DESCRIPTION
**What does this PR?**

Get the previous voted value from the API and set that value to the value of slider.
if user did not voted that post, it check the last voted value of any post from local Storage and set that value of slider.
If there is no last voted value in local Storage, it sets the by default value of slider. (for upSlider: 100 , for dowSlider: -1)

**Steps to reproduce**

1. Open any post and give vote to that post.
2. Open another post and give vote whatever you want to that post.
3. Open the link of that post in another window. you will see it sets the value that you set before while session storage is empty.
4. If the voted value of that post is preset in session storage , it picks the value from session storage and sets the value of slider. if not, then it will get the previous voted value by API call.

**Screenshot / Video**

https://user-images.githubusercontent.com/106739598/212050600-e705e6aa-9e03-4153-b0c0-eee2e40277cb.mp4



