### PR TITLE
Proposal's title count hotfix

### DIFF
--- a/src/common/components/proposal-votes/index.tsx
+++ b/src/common/components/proposal-votes/index.tsx
@@ -285,18 +285,19 @@ interface ProposalVotesProps {
 
 interface ProposalVotesState {
   searchText: string;
-  voteCount: number;
+  voteCount: string;
   isMoreData: boolean;
 }
 export class ProposalVotes extends Component<ProposalVotesProps, ProposalVotesState> {
   state: ProposalVotesState = {
     searchText: "",
-    voteCount: 0,
+    voteCount: "",
     isMoreData: true
   };
 
   getVotesCount = (num: number) => {
-    this.setState({ voteCount: num });
+    const voteCount = num.toString();
+    this.setState({ voteCount: voteCount });
   };
 
   checkIsMoreData = (check: boolean) => {
@@ -305,7 +306,7 @@ export class ProposalVotes extends Component<ProposalVotesProps, ProposalVotesSt
   render() {
     const { proposal, onHide } = this.props;
     const { searchText, voteCount, isMoreData } = this.state;
-    const modelTitle = isMoreData ? voteCount + "+" + " " : voteCount + " ";
+    const modalTitle = isMoreData && voteCount ? voteCount + "+" + " " : voteCount + " ";
     return (
       <Modal
         onHide={onHide}
@@ -317,7 +318,7 @@ export class ProposalVotes extends Component<ProposalVotesProps, ProposalVotesSt
       >
         <Modal.Header closeButton={true} className="align-items-center px-0">
           <Modal.Title>
-            {modelTitle + _t("proposals.votes-dialog-title", { n: proposal.id })}
+            {modalTitle + _t("proposals.votes-dialog-title", { n: proposal.id })}
           </Modal.Title>
         </Modal.Header>
         <Form.Group className="w-100 mb-3">


### PR DESCRIPTION
**What does this PR?**

It shows the correct number of votes in the proposal's  title.

**Bug**

As you can see in the video attached below.  When user try to gets the votes by just changing the page, it is working fine.
But when user search any thing and then change the page, it shows the wrong count. I debugged the issue and then correct it. 


https://user-images.githubusercontent.com/106739598/216985934-d639e0da-708d-4337-9814-9b7723f0ec93.mp4



**Steps to reproduce**

1. Open any proposal and change the page and see the number of votes on the title.
2. Search any user name and then change the page and jump into the last page. It will show the correct count on that proposal.
3. You can take help from the attached video.

Screenshot / Video 


https://user-images.githubusercontent.com/106739598/216985958-1d225082-23cc-4975-a719-6c4844491e00.mp4

