### PR TITLE
remove image width and height from source url

### DIFF
--- a/src/common/components/entry-list-item/index.tsx
+++ b/src/common/components/entry-list-item/index.tsx
@@ -219,12 +219,12 @@ export default class EntryListItem extends Component<Props, State> {
 
     const imgGrid: string =
       (global.canUseWebp
-        ? catchPostImage(entry, 600, 500, "webp")
-        : catchPostImage(entry, 600, 500)) || noImage;
+        ? catchPostImage(entry, 0, 0, "webp")
+        : catchPostImage(entry, 0, 0)) || noImage;
     const imgRow: string =
       (global.canUseWebp
-        ? catchPostImage(entry, 260, 200, "webp")
-        : catchPostImage(entry, 260, 200)) || noImage;
+        ? catchPostImage(entry, 0, 0, "webp")
+        : catchPostImage(entry, 0, 0)) || noImage;
     let svgSizeRow = imgRow === noImage ? "noImage" : "";
     let svgSizeGrid = imgGrid === noImage ? "172px" : "auto";
 


### PR DESCRIPTION
remove image width and height from source url, because constraints for image is size of box and with this property gifs don't work, this fix is according 
Fixes #1232 