### PR TITLE
Bug: Disabling notification alert toggle

### DIFF
--- a/src/common/components/dropdown/index.tsx
+++ b/src/common/components/dropdown/index.tsx
@@ -31,9 +31,11 @@ interface Props {
   onHide?: () => void;
   className?: string;
   withPadding?: boolean;
+  menuHide?: boolean;
 }
 
 const MyDropDown = (props: Props) => {
+  const { menuHide = true } = props;
   const [menu, setMenu] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -91,7 +93,9 @@ const MyDropDown = (props: Props) => {
   };
 
   const itemClicked = (i: MenuItem) => {
-    hideMenu();
+    if (menuHide) {
+      hideMenu();
+    }
 
     setTimeout(() => {
       if (i?.href) {
@@ -195,7 +199,8 @@ export default (p: Props) => {
     onShow: p?.onShow,
     onHide: p?.onHide,
     className: p?.className,
-    withPadding: p?.withPadding
+    withPadding: p?.withPadding,
+    menuHide: p?.menuHide
   };
 
   return <MyDropDown {...props} />;

--- a/src/common/components/notifications/index.tsx
+++ b/src/common/components/notifications/index.tsx
@@ -355,6 +355,7 @@ export class DialogContent extends Component<NotificationProps, any> {
                   NotifyTypes.TRANSFERS
                 )
               ]}
+              menuHide={false}
               history={this.props.history || history}
               label={
                 <span className={_c(`list-action ${loading ? "disabled" : ""}`)}>

--- a/src/common/constants/contributors.json
+++ b/src/common/constants/contributors.json
@@ -355,31 +355,31 @@
     "name": "solox",
     "contributes": ["Translation (Russian)"]
   },
- {
+  {
     "name": "alokkumar121",
     "contributes": ["Guest Curator"]
   },
- {
+  {
     "name": "pravesh0 ",
     "contributes": ["Guest Curator"]
   },
- {
+  {
     "name": "reeta0119",
     "contributes": ["Guest Curator"]
   },
- {
+  {
     "name": "ydaiznfts",
     "contributes": ["Guest Curator"]
   },
- {
+  {
     "name": "incublus",
     "contributes": ["Guest Curator"]
   },
-   {
+  {
     "name": "blessedkid-121",
     "contributes": ["Guest Curator"]
   },
- {
+  {
     "name": "jesustiano",
     "contributes": ["Guest Curator"]
   }


### PR DESCRIPTION
**What does this PR?**
Keeps the drop down open after toggling for the notification settings.
By default we set the value of menuHide to true. if the value coming from porps is false, it keeps the drop down open. otherwise it closes the drop down after click on item.

**Steps to reproduce**

1. Open the notifications and then open then hover on setting, it will open the drop down.
2. Toggle different options. it will keep open the drop down.

**Issue number** 

fixes #1202

**Screenshot / Video**


https://user-images.githubusercontent.com/106739598/220539602-bd70eedd-dfe9-469f-a4d2-12e7fc7fc52a.mp4

