### PR TITLE
If someone has voted but with zero rshares consider it an upvote

### DIFF
--- a/src/common/components/entry-vote-btn/index.tsx
+++ b/src/common/components/entry-vote-btn/index.tsx
@@ -236,7 +236,7 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
 
     const { active_votes: votes } = this.props.entry;
 
-    const upVoted = votes && votes.some((v) => v.voter === activeUser.username && v.rshares > 0);
+    const upVoted = votes && votes.some((v) => v.voter === activeUser.username && v.rshares >= 0);
 
     const downVoted = votes && votes.some((v) => v.voter === activeUser.username && v.rshares < 0);
 


### PR DESCRIPTION
A previous hardfork allowed Resource Credits to be delegated, which in turn allows accounts with zero HP to vote. The result is that an account can have voted posts and the vote is not rendered properly because rshares = 0 due to no HP but having resource credits to vote.

Upvoting works but it is not rendered properly. Downvoting with 0 HP is not possible. So a vote with 0 rshares should be considered an upvote.

Upvoting with zero HP works:
![image](https://user-images.githubusercontent.com/21374091/220900211-bc8d34b4-d64f-4f4b-8fdd-4a52faee070a.png)
![image](https://user-images.githubusercontent.com/21374091/220900234-78cf4220-3af1-4f80-bf5b-cd124214d2c7.png)


Downvoting with zero HP is not possible:
![image](https://user-images.githubusercontent.com/21374091/220900305-f86f4613-9a51-4b08-96b0-0ec9e701196f.png)

