### PR TITLE
Added caching level for trading view

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "sortablejs": "^1.13.0",
     "speakingurl": "^14.0.1",
     "use-async-effect": "^2.2.6",
+    "use-indexeddb": "^2.0.2",
     "xss": "^1.0.8"
   },
   "devDependencies": {

--- a/src/common/api/hive.ts
+++ b/src/common/api/hive.ts
@@ -1,4 +1,4 @@
-import { Client, RCAPI, utils } from "@hiveio/dhive";
+import { Client, RCAPI } from "@hiveio/dhive";
 
 import { RCAccount } from "@hiveio/dhive/lib/chain/rc";
 

--- a/src/common/components/market-advanced-mode/api/index.ts
+++ b/src/common/components/market-advanced-mode/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./trading-view-api";

--- a/src/common/components/market-advanced-mode/api/trading-view-api.ts
+++ b/src/common/components/market-advanced-mode/api/trading-view-api.ts
@@ -1,0 +1,49 @@
+import { MarketCandlestickDataItem } from "../../../api/hive";
+import moment from "moment/moment";
+import { Time } from "lightweight-charts";
+import { useState } from "react";
+import { useTradingViewCache } from "../caching";
+import { Moment } from "moment";
+
+export function useTradingViewApi(setData: (value: MarketCandlestickDataItem[]) => void) {
+  const { getCachedMarketHistory } = useTradingViewCache();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [originalData, setOriginalData] = useState<MarketCandlestickDataItem[]>([]);
+
+  const fetchData = async (
+    bucketSeconds: number,
+    startDate: Moment,
+    endDate: Moment,
+    loadMore?: boolean
+  ) => {
+    setIsLoading(true);
+    const apiData = await getCachedMarketHistory(bucketSeconds, startDate, endDate);
+    let transformedData: MarketCandlestickDataItem[] = [];
+
+    if (loadMore) {
+      transformedData = [...originalData, ...apiData];
+    } else {
+      transformedData = apiData;
+    }
+    setOriginalData(transformedData);
+
+    const dataMap = transformedData
+      .map(({ hive, non_hive, open }) => ({
+        close: non_hive.close / hive.close,
+        open: non_hive.open / hive.open,
+        low: non_hive.low / hive.low,
+        high: non_hive.high / hive.high,
+        volume: hive.volume,
+        time: Math.floor(moment(open).toDate().getTime() / 1000) as Time
+      }))
+      .reduce((acc, item) => acc.set(item.time, item), new Map<Time, any>());
+    setIsLoading(false);
+
+    setData(Array.from(dataMap.values()).sort((a, b) => Number(a.time) - Number(b.time)));
+  };
+
+  return {
+    fetchData
+  };
+}

--- a/src/common/components/market-advanced-mode/caching/index.ts
+++ b/src/common/components/market-advanced-mode/caching/index.ts
@@ -1,0 +1,1 @@
+export * from "./trading-view-caching";

--- a/src/common/components/market-advanced-mode/caching/trading-view-caching.ts
+++ b/src/common/components/market-advanced-mode/caching/trading-view-caching.ts
@@ -1,0 +1,131 @@
+import "use-indexeddb";
+import setupIndexedDB, { useIndexedDBStore } from "use-indexeddb";
+import { useEffect } from "react";
+import { IndexedDBConfig } from "use-indexeddb/dist/interfaces";
+import { getMarketHistory, MarketCandlestickDataItem } from "../../../api/hive";
+import moment, { Moment } from "moment";
+
+interface MarketCandlestickDataRecord extends MarketCandlestickDataItem {
+  openDate: Moment;
+}
+
+interface MarketDataRecord {
+  date: string;
+  data: string;
+  seconds: number;
+}
+
+const MARKET_DB_CONFIG: IndexedDBConfig = {
+  databaseName: "ecency",
+  version: 1,
+  stores: [
+    {
+      name: "tv_hbd_hive",
+      id: { keyPath: "id", autoIncrement: true },
+      indices: [
+        { name: "date", keyPath: "date" },
+        { name: "data", keyPath: "data" },
+        { name: "seconds", keyPath: "seconds" }
+      ]
+    }
+  ]
+};
+
+/**
+ *
+ * @param ttl Time to live (hours)
+ * @param version DB version
+ */
+export function useTradingViewCache(ttl: number | "none" = "none", version: number = 1) {
+  const { add, update, getOneByKey, getManyByKey } =
+    useIndexedDBStore<MarketDataRecord>("tv_hbd_hive");
+
+  useEffect(() => {
+    setupIndexedDB({
+      ...MARKET_DB_CONFIG,
+      version
+    })
+      .then(() => console.debug("Market caches started!"))
+      .catch(() => console.error("Failed to start market caches."));
+  }, []);
+
+  /**
+   * Get cached records from DB based on params
+   * @param seconds
+   * @param startDate
+   * @param endDate
+   */
+  const getCached = async (seconds: number, startDate?: Moment, endDate?: Moment) => {
+    // Fetch all records of current bucket
+    const items = await getManyByKey("seconds", seconds);
+
+    // Parse candlestick data
+    let candlestickRecords = items
+      .map((item) => JSON.parse(item.data) as MarketCandlestickDataRecord)
+      .map((item) => ({
+        ...item,
+        openDate: moment(item.open)
+      }));
+    candlestickRecords = candlestickRecords
+      .sort((a, b) => (a.openDate.isBefore(b.openDate) ? -1 : 1))
+      // Filter all records for current time period
+      .filter((item) =>
+        !startDate || !endDate
+          ? true
+          : startDate.isSameOrBefore(item.openDate) && endDate.isSameOrAfter(item.openDate)
+      );
+
+    return candlestickRecords;
+  };
+
+  const cache = async (response: MarketCandlestickDataItem[], seconds: number) => {
+    for (const item of response) {
+      const existingItem = await getOneByKey("date", item.open);
+
+      if (existingItem) {
+        await update({
+          date: item.open,
+          data: JSON.stringify(item),
+          seconds
+        });
+      } else {
+        await add({
+          date: item.open,
+          data: JSON.stringify(item),
+          seconds
+        });
+      }
+    }
+  };
+
+  const getCachedMarketHistory = async (
+    seconds: number,
+    startDate: Moment,
+    endDate: Moment
+  ): Promise<MarketCandlestickDataItem[]> => {
+    const cached = await getCached(seconds, startDate, endDate);
+    if (cached.length > 0) {
+      return cached;
+      // const isLookingForPast = endDate.isBefore(moment());
+      // const isFullCached = cached[0].openDate.isSame(startDate);
+      // if (isLookingForPast) {
+      //   if (isFullCached) {
+      //     return cached;
+      //   } else {
+      //     const newPeriod = [startDate, cached[0].openDate];
+      //     const newRecordsResponse = await getMarketHistory(seconds, newPeriod[0], newPeriod[1]);
+      //     await cache(newRecordsResponse, seconds);
+      //     return [...newRecordsResponse, ...cached];
+      //   }
+      // }
+    }
+
+    const response = await getMarketHistory(seconds, startDate, endDate);
+    await cache(response, seconds);
+    return response;
+  };
+
+  return {
+    getCachedMarketHistory
+  };
+}

--- a/src/common/components/recovery-account/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/recovery-account/__snapshots__/index.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`(1) Default render 1`] = `
         className="form-label"
         htmlFor="account-name"
       >
-        Current Recovery Account
+        Current Recovery Agent
       </label>
       <input
         className="form-control"
@@ -32,7 +32,7 @@ exports[`(1) Default render 1`] = `
         className="form-label"
         htmlFor="cur-pass"
       >
-        New Recovery Account
+        New Recovery Agent
       </label>
       <input
         autoComplete="off"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12207,6 +12207,11 @@ use-async-effect@^2.2.6:
   resolved "https://registry.yarnpkg.com/use-async-effect/-/use-async-effect-2.2.6.tgz#00f2dee71e2f6188c5daf6a067e2bc151f7566b7"
   integrity sha512-wKUpaHkuF4rzBHawP87o1KzoK2IxJ6De8fUyQ3GN2114zb4zqT87+SEbCHS+F+0inZ2Y+k6Tm1LOCQgYTSD9ww==
 
+use-indexeddb@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/use-indexeddb/-/use-indexeddb-2.0.2.tgz#b1e174e28e7c5e63641c900d796734b028666b70"
+  integrity sha512-pF1Gnrdg7wYvSKAXQvITP0KDVFnecjfckxLAtne6WYDJfbGaeOG7038sZjpR9SrcS9xrjKLJSjeakkYzHyhhEw==
+
 use-memo-one@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"


### PR DESCRIPTION
Added caching level for trading view widget, it works like next:
1. Request data from `useTradingViewApi` hook;
2. It gets time period and bucket size and checks if database have some records in this interval;
3. If data exists in database return them else fetch from API;
4. Save got response to cache based on bucket size and date time.