### PR TITLE
Night theme photo zoom resolved

### DIFF
--- a/src/common/components/entry-body-extra/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/entry-body-extra/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntryBodyExtra component renders correctly 1`] = `null`;

--- a/src/common/components/entry-body-extra/index.spec.tsx
+++ b/src/common/components/entry-body-extra/index.spec.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import EntryBodyExtra from "./index";
+import { entryInstance1, globalInstance } from "../../helper/test-helper";
+
+describe("EntryBodyExtra component", () => {
+  const props = {
+    entry: { ...entryInstance1 },
+    global: globalInstance
+  };
+
+  it("renders correctly", () => {
+    const tree = renderer.create(<EntryBodyExtra {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/common/components/entry-body-extra/index.tsx
+++ b/src/common/components/entry-body-extra/index.tsx
@@ -3,15 +3,26 @@ import React, { Component } from "react";
 import mediumZoom, { Zoom } from "medium-zoom";
 
 import { Entry } from "../../store/entries/types";
+import { Global, Theme } from "../../store/global/types";
 
 import { injectTwitter } from "../../util/twitter";
+import { useMappedStore } from "../../store/use-mapped-store";
 
 interface Props {
   entry: Entry;
+  global: Global;
 }
 
 class EntryBodyExtra extends Component<Props> {
   zoom: Zoom | null = null;
+
+  setBackground = () => {
+    if (this.props.global.theme === Theme.day) {
+      this.zoom?.update({ background: "#FFFFFF" });
+    } else {
+      this.zoom?.update({ background: "#000000" });
+    }
+  };
 
   componentDidMount() {
     const { entry } = this.props;
@@ -26,6 +37,13 @@ class EntryBodyExtra extends Component<Props> {
       ...document.querySelectorAll<HTMLElement>(".entry-body img")
     ].filter((x) => x.parentNode?.nodeName !== "A");
     this.zoom = mediumZoom(elements);
+    this.setBackground();
+  }
+
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (prevProps.global.theme !== this.props.global.theme) {
+      this.setBackground();
+    }
   }
 
   componentWillUnmount() {
@@ -40,8 +58,10 @@ class EntryBodyExtra extends Component<Props> {
 }
 
 export default (p: Props) => {
+  const { global } = useMappedStore();
   const props = {
-    entry: p.entry
+    entry: p.entry,
+    global: global
   };
 
   return <EntryBodyExtra {...props} />;

--- a/src/common/components/entry-body-extra/index.tsx
+++ b/src/common/components/entry-body-extra/index.tsx
@@ -18,9 +18,9 @@ class EntryBodyExtra extends Component<Props> {
 
   setBackground = () => {
     if (this.props.global.theme === Theme.day) {
-      this.zoom?.update({ background: "#FFFFFF" });
+      this.zoom?.update({ background: "#ffffff" });
     } else {
-      this.zoom?.update({ background: "#000000" });
+      this.zoom?.update({ background: "#131111" });
     }
   };
 

--- a/src/common/components/entry-body-extra/index.tsx
+++ b/src/common/components/entry-body-extra/index.tsx
@@ -6,7 +6,6 @@ import { Entry } from "../../store/entries/types";
 import { Global, Theme } from "../../store/global/types";
 
 import { injectTwitter } from "../../util/twitter";
-import { useMappedStore } from "../../store/use-mapped-store";
 
 interface Props {
   entry: Entry;
@@ -58,10 +57,9 @@ class EntryBodyExtra extends Component<Props> {
 }
 
 export default (p: Props) => {
-  const { global } = useMappedStore();
   const props = {
     entry: p.entry,
-    global: global
+    global: p.global
   };
 
   return <EntryBodyExtra {...props} />;

--- a/src/common/pages/entry.tsx
+++ b/src/common/pages/entry.tsx
@@ -1308,7 +1308,7 @@ class EntryPage extends BaseComponent<Props, State> {
           </div>
         </div>
         {editHistory && <EditHistory entry={entry} onHide={this.toggleEditHistory} />}
-        <EntryBodyExtra entry={entry} />
+        <EntryBodyExtra entry={entry} global={global} />
       </>
     );
   }


### PR DESCRIPTION
**What does this PR?**


when entry images are zoom in, it Changes the background color of Entry Images according to the theme of the website. If theme is "Day" , it shows the background of entry images is "White". But when the theme is "Night" , it shows the background "Black".

**Steps to reproduce**

1. Open any Entry and click on the image of that entry. If your theme is "Day", it will show the background color to "White". But 
   if your theme is "Night", it will show the background color to "Black".

**Issue number** 

fixes #1226

**Screenshot / Video**

Bug: In Both "Day" and "Night" theme, the background of the entry images are white.

https://user-images.githubusercontent.com/106739598/224990371-d6d56aa5-613c-4980-8363-10ba5a0d359d.mp4


After Bug is Resolved: In "Day" theme the background of entry images is "white" while in "night" theme, the background of entry images is Black
 

https://user-images.githubusercontent.com/106739598/224990736-404d16a7-6870-4e03-8c5a-de6291f952c0.mp4

