### PR TITLE
Fix styling of search list suggestion

### DIFF
--- a/src/common/components/converts-collateralized/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/converts-collateralized/__snapshots__/index.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`(1) Default render 1`] = `
               className="date"
               title="Saturday, September 17, 2022 1:42 AM"
             >
-              6 months ago
+              7 months ago
             </div>
           </td>
         </tr>

--- a/src/common/components/search-suggester/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/search-suggester/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(1) Default render 1`] = `
+<div
+  className="suggestion"
+>
+  <a>
+    Search
+  </a>
+  <div />
+</div>
+`;

--- a/src/common/components/search-suggester/index.spec.tsx
+++ b/src/common/components/search-suggester/index.spec.tsx
@@ -3,12 +3,7 @@ import SearchSuggester from "./index";
 import renderer from "react-test-renderer";
 import { BrowserRouter } from "react-router-dom";
 import { createBrowserHistory, createLocation } from "history";
-import {
-  activeUserInstance,
-  globalInstance,
-  allOver,
-  TrendingTagsInstance
-} from "../../helper/test-helper";
+import { globalInstance, TrendingTagsInstance } from "../../helper/test-helper";
 
 it("(1) Default render", () => {
   const props = {

--- a/src/common/components/search-suggester/index.spec.tsx
+++ b/src/common/components/search-suggester/index.spec.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import SearchSuggester from "./index";
+import renderer from "react-test-renderer";
+import { BrowserRouter } from "react-router-dom";
+import { createBrowserHistory, createLocation } from "history";
+import {
+  activeUserInstance,
+  globalInstance,
+  allOver,
+  TrendingTagsInstance
+} from "../../helper/test-helper";
+
+it("(1) Default render", () => {
+  const props = {
+    history: createBrowserHistory(),
+    location: createLocation({}),
+    global: globalInstance,
+    trendingTags: TrendingTagsInstance,
+    value: "",
+    children: <a>Search</a>,
+    containerClassName: "",
+    changed: false
+  };
+  const component = renderer.create(
+    <BrowserRouter>
+      <SearchSuggester {...props} />
+    </BrowserRouter>
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/src/common/components/search-suggester/index.tsx
+++ b/src/common/components/search-suggester/index.tsx
@@ -165,12 +165,12 @@ export class SearchSuggester extends BaseComponent<Props, State> {
         .filter((x: string) => x.toLowerCase().indexOf(value.toLowerCase()) === 0)
         .filter((x: string) => x.indexOf("hive-") === -1)
         .map((x) => `#${x}`)
-        .slice(0, limit_result);
+        .slice(0, 2);
       // account
-      const lookup_accounts = await lookupAccounts(value, limit_result - 2);
+      const lookup_accounts = await lookupAccounts(value, 2);
       const accounts_suggestions = lookup_accounts.map((x) => `@${x}`);
       // Community
-      const get_communities = await getCommunities("", limit_result, value);
+      const get_communities = await getCommunities("", 2, value);
       const communities_suggestions = get_communities || [];
       const suggestionWithMode = [
         {

--- a/src/common/components/search-suggester/index.tsx
+++ b/src/common/components/search-suggester/index.tsx
@@ -159,7 +159,6 @@ export class SearchSuggester extends BaseComponent<Props, State> {
 
     // Search ALL
     if (!!value) {
-      const limit_result = 5;
       // tags
       const tags_suggestions = trendingTags.list
         .filter((x: string) => x.toLowerCase().indexOf(value.toLowerCase()) === 0)

--- a/src/common/components/suggestion-list/__snapshots__/index.spec.tsx.snap
+++ b/src/common/components/suggestion-list/__snapshots__/index.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`(2) Show list 1`] = `
       className="suggestion-list-parent"
     >
       <div
-        className="suggestion-list"
+        className="search-suggestion-list"
       >
         <div
           className="list-header"
@@ -60,7 +60,7 @@ exports[`(2) Show list 1`] = `
         </div>
       </div>
       <div
-        className="suggestion-list mt-1"
+        className="search-suggestion-list more-result"
       >
         <div
           className="list-body"

--- a/src/common/components/suggestion-list/_index.scss
+++ b/src/common/components/suggestion-list/_index.scss
@@ -15,7 +15,6 @@
   }
 
   .search-suggestion-list {
-    // position: absolute;
     display: block;
     left: 0;
     top: 100%;
@@ -73,7 +72,7 @@
 
           &:hover,
           &:focus {
-            background: $dark-seven;
+            background: $metallic-blue;
             color: $white;
           }
         }

--- a/src/common/components/suggestion-list/_index.scss
+++ b/src/common/components/suggestion-list/_index.scss
@@ -14,8 +14,8 @@
     z-index: 99;
   }
 
-  .suggestion-list {
-    position: absolute;
+  .search-suggestion-list {
+    // position: absolute;
     display: block;
     left: 0;
     top: 100%;
@@ -73,10 +73,33 @@
 
           &:hover,
           &:focus {
-            background: $metallic-blue;
+            background: $dark-seven;
             color: $white;
           }
         }
+      }
+    }
+  }
+  .more-result {
+    .list-item {
+      @include themify(day) {
+        background: $white-four !important;
+
+        &:hover,
+        &:focus {
+          color: $dark !important;
+        }
+      }
+
+      @include themify(night) {
+        color: $white !important;
+        background: $dark-indigo !important;
+      }
+    }
+
+    .list-item {
+      &:last-child {
+        border-radius: 0 !important;
       }
     }
   }

--- a/src/common/components/suggestion-list/index.tsx
+++ b/src/common/components/suggestion-list/index.tsx
@@ -47,6 +47,12 @@ export default class SuggestionList extends Component<Props> {
     }
   }
 
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (prevProps.modeItems !== this.props.modeItems && this.props.modeItems!.length > 0) {
+      this.setState({ showList: true });
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener("keydown", this.watchKb);
     document.removeEventListener("click", this.watchClick);
@@ -156,7 +162,7 @@ export default class SuggestionList extends Component<Props> {
           const _items = modeItem.items;
           return (
             _items.length > 0 && (
-              <div className="suggestion-list" key={modeKey}>
+              <div className="search-suggestion-list" key={modeKey}>
                 {modeItem.header && <div className="list-header">{modeItem.header}</div>}
                 <div className="list-body">
                   {_items.map((x: any, i: number) => {
@@ -181,7 +187,7 @@ export default class SuggestionList extends Component<Props> {
             )
           );
         })}
-        <div className="suggestion-list mt-1">
+        <div className="search-suggestion-list more-result">
           <div className="list-body">
             <a href="#" className="list-item" onClick={this.moreResultsClick}>
               {_t("g.more-results")}


### PR DESCRIPTION
**What does this PR?**
Fix the rendering of search suggestion component. Sometime after writing any query in the search box, it do not shows any searched result.
Shows the searched result in the such format that shows Tags , Users and then communities and "more results" button at the bottom of the list.

**Steps to reproduce**

1.Type anything in the search bar like shadow , game and whatever of your own choice. If there will be any tags, users and communities corresponding to that word, it will show just 2 tags, user and communities.
2. You can take guideline from the attached vide.

**Issue number** 

fixes #1269 

**Screenshot / Video**


https://user-images.githubusercontent.com/106739598/226357718-0145d0fd-62e0-4b87-ab2a-558cfe928285.mp4


