### PR TITLE
Bug/edit community settings

### DIFF
--- a/src/common/components/rc-delegation/index.tsx
+++ b/src/common/components/rc-delegation/index.tsx
@@ -14,14 +14,8 @@ import { arrowRightSvg } from "../../img/svg";
 import { _t } from "../../i18n";
 
 export const ResourceCreditsDelegation = (props: any) => {
-  const { 
-    resourceCredit, 
-    activeUser, 
-    hideDelegation, 
-    toFromList, 
-    amountFromList, 
-    delegateeData 
-  } = props;
+  const { resourceCredit, activeUser, hideDelegation, toFromList, amountFromList, delegateeData } =
+    props;
 
   const [to, setTo] = useState<string>(toFromList || "");
   const [amount, setAmount] = useState<any>(amountFromList || "");

--- a/src/common/pages/community-functional.tsx
+++ b/src/common/pages/community-functional.tsx
@@ -215,7 +215,12 @@ export const CommunityPage = (props: Props) => {
         }
       >
         <div className="profile-side">
-          <CommunityCard {...props} account={account} community={community} />
+          <CommunityCard
+            {...props}
+            account={account}
+            community={community}
+            addCommunity={setCommunity}
+          />
         </div>
         <span itemScope={true} itemType="http://schema.org/Organization">
           <meta itemProp="name" content={community.title.trim() || community.name} />

--- a/src/common/pages/profile-functional.tsx
+++ b/src/common/pages/profile-functional.tsx
@@ -573,7 +573,9 @@ export const Profile = (props: Props) => {
 
                 if (data !== undefined) {
                   let entryList = data?.entries;
-                  entryList = entryList.filter((item) => item.permlink !== (account as FullAccount)?.profile?.pinned);
+                  entryList = entryList.filter(
+                    (item) => item.permlink !== (account as FullAccount)?.profile?.pinned
+                  );
                   if (pinnedEntry) {
                     entryList.unshift(pinnedEntry);
                   }


### PR DESCRIPTION

**Bug Description:**

I think I found an issue. On a brand new community, I went to the community page with my own (ADMIN) account.
I clicked on "Edit Settings" and spent some time entering Description and Rules.
Then I clicked "Save". It took a few seconds, there was no error reported.
The info I typed appeared on the left-hand side of the Community Page.
I refreshed the page, F5, and all the info disappeared. Waited some time and refreshed several times, it still show the initial info, meaning Desc & Rules are empty. It didn't cross my mind I could get to such problem so I have to write it again. Probably better use a text editor this time first.

**What does this PR?**
Saved the community settings after clicking on save button.

**Steps to reproduce**

1. Login with admin account of any community.
2.Go to profile and then click on communities. click on any community.
3. Click on the edit settings button that is the on the left side of the community page. 
4. Write any thing in description and rules and then click on save. after clicking on save you will see the latest changing.


**Issue number** 

fixes #1045


**Screenshot / videos**
 

https://user-images.githubusercontent.com/106739598/228152077-36874f3a-29b2-4b14-b1c7-26c3dd8d5af7.mp4

