### PR TITLE
Account Recovery Hotfix

### DIFF
--- a/src/common/components/recovery-account/index.tsx
+++ b/src/common/components/recovery-account/index.tsx
@@ -70,7 +70,7 @@ export default function AccountRecovery(props: Props) {
     e.persist();
     setNewCurrRecoveryAccount(e.target.value);
 
-    if (e.target.value.length == 0) {
+    if (e.target.value.length === 0) {
       setDisabled(true);
       setToError("");
       return;
@@ -79,6 +79,11 @@ export default function AccountRecovery(props: Props) {
       if (resp) {
         setDisabled(false);
         setToError("");
+        if (resp && e.target.value === props.activeUser?.username) {
+          setDisabled(true);
+          setToError(_t("account-recovery.same-account-error"));
+          return;
+        }
       } else {
         if (e.target.value.length > 0) {
           setDisabled(true);

--- a/src/common/components/recovery-account/index.tsx
+++ b/src/common/components/recovery-account/index.tsx
@@ -134,6 +134,7 @@ export default function AccountRecovery(props: Props) {
   const finish = () => {
     setKeyDialog(false);
     setNewCurrRecoveryAccount("");
+    setDisabled(true);
   };
 
   const handleConfirm = () => {
@@ -156,17 +157,13 @@ export default function AccountRecovery(props: Props) {
             <div className="confirmation">
               <div className="users">
                 <div className="from-user">
-                  {UserAvatar({
-                    ...props,
-                    username: props.activeUser!.username,
-                    size: "large"
-                  })}
+                  <UserAvatar username={props.activeUser!.username} size="large" />
                 </div>
 
                 <>
                   <div className="arrow">{arrowRightSvg}</div>
                   <div className="to-user">
-                    {UserAvatar({ ...props, username: newRecoveryAccount, size: "large" })}
+                    <UserAvatar username={newRecoveryAccount} size="large" />
                   </div>
                 </>
               </div>

--- a/src/common/i18n/locales/en-US.json
+++ b/src/common/i18n/locales/en-US.json
@@ -1488,7 +1488,8 @@
     "sign-title": "Sign transaction",
     "sign-sub-title": "Sign your transaction",
     "success-message": "New recovery agent is effective after 30 days",
-    "info-message": "Overwrite pending request? @{{n}}"
+    "info-message": "Overwrite pending request? @{{n}}",
+    "same-account-error": "You can't set yourself as recovery account!"
   },
   "add-image": {
     "title": "Add Image",


### PR DESCRIPTION
**Bug:** When you try to change the recovery account , the app crashes due to changing in the UserAvatar component. The UserAvatar component was getting props from the parent component and after implementing useMappedStore hook , it has to get just some props like userName and size etc. 
This is the reason of crash the app.
I am mentioning the video when you try to change the recovery account in ecency , it crashes the app.


**Account Recovery Bug :** 


https://user-images.githubusercontent.com/106739598/228505762-0c40104f-2f0e-46df-bdfd-29e8a404eec9.mp4



**Bug Fix:**

Now you can change your recovery account.

https://user-images.githubusercontent.com/106739598/228505892-e57629ab-dc63-421e-828c-aa3463dfb3a2.mp4


