### PR TITLE
Hotfix

### DIFF
--- a/src/common/components/recovery-account/index.tsx
+++ b/src/common/components/recovery-account/index.tsx
@@ -123,14 +123,14 @@ export default function AccountRecovery(props: Props) {
     e: React.ChangeEvent<typeof FormControl & HTMLInputElement>
   ) => {
     e.persist();
+    setIsEcency(e.target.value === ECENCY);
+    setNewCurrRecoveryAccount(e.target.value);
 
     if (e.target.value.length === 0) {
       setDisabled(true);
       setToError("");
       return;
     }
-    setIsEcency(e.target.value === ECENCY);
-    setNewCurrRecoveryAccount(e.target.value);
   };
 
   const update = () => {


### PR DESCRIPTION
The issue is that input field of account recovery is not reset to empty. During implementing debouncing, the state Set function of newRecoveryAccount  moved after the if condition that was the reason of the issue. When we try to empty the input field, it keeps the first input value in it.
I found the issue while i was testing this feature in alpha.ececny.com. 
I fix the issue and made a PR.


Issue Vide:

https://user-images.githubusercontent.com/106739598/232775576-84f36137-5d4b-4f6f-ab2c-02adb4887271.mp4



Issue Fix Video:

https://user-images.githubusercontent.com/106739598/232775073-a4cd343a-7cbe-41bd-83d7-2c52834b74b4.mp4

