### PR TITLE
Change some styling of help-btn and feedback component

### DIFF
--- a/src/common/components/feedback/_index.scss
+++ b/src/common/components/feedback/_index.scss
@@ -50,10 +50,9 @@
 
     svg {
       height: 20px;
-      // margin-right: 6px;
     }
     .feedback-body {
-      padding: 24px 6px 0px 6px;
+      padding: 30px 6px 0px 6px;
     }
 
     .feedback-content {
@@ -72,12 +71,21 @@
     }
     .feedback-close-btn {
       position: absolute;
-      right: 6px;
-      margin-top: -19px;
+      right: 8px;
+      margin-top: -22px;
       cursor: pointer;
+
+      @media (max-width: $md-break) {
+        svg {
+          display: block;
+          width: 15px;
+          height: 15px;
+        }
+      }
+
       @include themify(day) {
         svg {
-          color: $dark-three;
+          color: $charcoal-grey;
         }
       }
       @include themify(night) {

--- a/src/common/components/feedback/_index.scss
+++ b/src/common/components/feedback/_index.scss
@@ -77,7 +77,7 @@
       cursor: pointer;
       @include themify(day) {
         svg {
-          color: $charcoal-grey;
+          color: $dark-three;
         }
       }
       @include themify(night) {

--- a/src/common/components/floating-faq/index.scss
+++ b/src/common/components/floating-faq/index.scss
@@ -9,8 +9,6 @@
   right: 2rem;
   bottom: 1rem;
   border-radius: 20px 2px 20px 20px !important;
-  height: 40px;
-
   .help {
     display: inline-block;
     margin-left: 0.4rem;
@@ -20,6 +18,15 @@
 
   .help-button-content {
     margin-top: -3px;
+  }
+}
+
+@media (max-width: 791px) {
+  .help-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 50% !important;
+    padding: 0 !important;
   }
 }
 

--- a/src/common/components/floating-faq/index.scss
+++ b/src/common/components/floating-faq/index.scss
@@ -9,6 +9,7 @@
   right: 2rem;
   bottom: 1rem;
   border-radius: 20px 2px 20px 20px !important;
+  height: 40px;
   .help {
     display: inline-block;
     margin-left: 0.4rem;
@@ -24,7 +25,7 @@
 @media (max-width: 791px) {
   .help-btn {
     width: 40px;
-    height: 40px;
+
     border-radius: 50% !important;
     padding: 0 !important;
   }

--- a/src/common/components/floating-faq/index.scss
+++ b/src/common/components/floating-faq/index.scss
@@ -25,7 +25,6 @@
 @media (max-width: 791px) {
   .help-btn {
     width: 40px;
-
     border-radius: 50% !important;
     padding: 0 !important;
   }


### PR DESCRIPTION
Make x icon of feedback message a little bit dark.
Make floating-help button consistent with scroll-to-top on mobile screen.


https://github.com/ecency/ecency-vision/assets/106739598/da743a7f-9ee5-4059-abd8-4b8e5e2b80db

