### PR TITLE
Close the voting slider after tip is done on the 7 days old post

### DIFF
--- a/src/common/components/announcement/index.scss
+++ b/src/common/components/announcement/index.scss
@@ -100,7 +100,7 @@
 
   .close-btn {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
+    top: 7px;
+    right: 3px;
   }
 }

--- a/src/common/components/entry-tip-btn/index.spec.tsx
+++ b/src/common/components/entry-tip-btn/index.spec.tsx
@@ -17,7 +17,8 @@ const defProps = {
   },
   entry: entryInstance1,
   updateWalletValues: () => {},
-  setTipDialogMounted: () => {}
+  setTipDialogMounted: () => {},
+  handleClickAway: () => {}
 };
 
 it("(1) Default render", async () => {

--- a/src/common/components/entry-tip-btn/index.tsx
+++ b/src/common/components/entry-tip-btn/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   toggleUIProp: (what: ToggleType) => void;
   setSigningKey: (key: string) => void;
   setTipDialogMounted?: (d: boolean) => void;
+  handleClickAway?: () => void;
 }
 
 interface DialogProps extends Props {
@@ -58,7 +59,7 @@ export class TippingDialog extends Component<DialogProps> {
   }
 
   render() {
-    const { global, entry, activeUser } = this.props;
+    const { global, entry, activeUser, handleClickAway } = this.props;
 
     if (!activeUser) {
       return null;
@@ -82,6 +83,7 @@ export class TippingDialog extends Component<DialogProps> {
         amount={global.usePrivate ? "100.000" : "1.000"}
         to={to}
         memo={memo}
+        handleClickAway={handleClickAway}
       />
     );
   }
@@ -143,8 +145,12 @@ export default ({
   entry,
   account,
   updateWalletValues,
-  setTipDialogMounted
-}: Pick<Props, "entry" | "account" | "updateWalletValues" | "setTipDialogMounted">) => {
+  setTipDialogMounted,
+  handleClickAway
+}: Pick<
+  Props,
+  "entry" | "account" | "updateWalletValues" | "setTipDialogMounted" | "handleClickAway"
+>) => {
   const {
     users,
     ui,
@@ -173,6 +179,7 @@ export default ({
     fetchPoints: fetchPoints,
     updateWalletValues: updateWalletValues,
     setTipDialogMounted: setTipDialogMounted,
+    handleClickAway: handleClickAway,
     addAccount: addAccount,
     setActiveUser: setActiveUser,
     updateActiveUser: updateActiveUser,

--- a/src/common/components/entry-vote-btn/index.spec.tsx
+++ b/src/common/components/entry-vote-btn/index.spec.tsx
@@ -66,7 +66,8 @@ describe("(1) Dialog", () => {
     previousVotedValue: null,
     onClick: () => {},
     setTipDialogMounted: () => {},
-    updateWalletValues: () => {}
+    updateWalletValues: () => {},
+    handleClickAway: () => {}
   };
 
   const renderer = withStore(<VoteDialog {...props} />);

--- a/src/common/components/entry-vote-btn/index.tsx
+++ b/src/common/components/entry-vote-btn/index.tsx
@@ -83,6 +83,7 @@ interface VoteDialogProps {
   setTipDialogMounted: (d: boolean) => void;
   updateWalletValues: () => void;
   onClick: (percent: number, estimated: number) => void;
+  handleClickAway: () => void;
 }
 
 interface VoteDialogState {
@@ -424,6 +425,7 @@ export class VoteDialog extends Component<VoteDialogProps, VoteDialogState> {
                   account={this.props.account}
                   updateWalletValues={this.props.updateWalletValues}
                   setTipDialogMounted={this.props.setTipDialogMounted}
+                  handleClickAway={this.props.handleClickAway}
                 />
               </div>
             </div>
@@ -653,6 +655,7 @@ export class EntryVoteBtn extends BaseComponent<Props, State> {
                               setTipDialogMounted={this.setTipDialogMounted}
                               updateWalletValues={this.ensureAccount}
                               onClick={this.vote}
+                              handleClickAway={this.handleClickAway}
                             />
                           </span>
                         </div>

--- a/src/common/components/transfer/index.spec.tsx
+++ b/src/common/components/transfer/index.spec.tsx
@@ -43,7 +43,8 @@ const defProps = {
   setSigningKey: () => {},
   fetchPoints: () => {},
   updateWalletValues: () => {},
-  onHide: () => {}
+  onHide: () => {},
+  handleClickAway: () => {}
 };
 
 describe("(1) Transfer HIVE", () => {

--- a/src/common/components/transfer/index.tsx
+++ b/src/common/components/transfer/index.tsx
@@ -144,6 +144,7 @@ interface Props {
   fetchPoints: (username: string, type?: number) => void;
   updateWalletValues: () => void;
   onHide: () => void;
+  handleClickAway?: () => void;
 }
 
 interface State {
@@ -620,8 +621,16 @@ export class Transfer extends BaseComponent<Props, State> {
   };
 
   finish = () => {
-    const { onHide, mode, asset, account, activeUser, fetchPoints, updateWalletValues } =
-      this.props;
+    const {
+      onHide,
+      mode,
+      asset,
+      account,
+      activeUser,
+      fetchPoints,
+      updateWalletValues,
+      handleClickAway
+    } = this.props;
     if (account && activeUser && account.name !== activeUser.username) {
       if (mode === "transfer" && asset === "POINT") {
         fetchPoints(account.name);
@@ -631,6 +640,7 @@ export class Transfer extends BaseComponent<Props, State> {
     }
     // const {onHide} = this.props;
     onHide();
+    handleClickAway && handleClickAway();
   };
 
   reset = () => {


### PR DESCRIPTION
I have noticed that the voting slider should be close after the tip is done on that post that is older than 7 days.
I fix this issue.


**Issue Video:**

https://github.com/ecency/ecency-vision/assets/106739598/5037f0a6-9818-473b-b346-112bae50c574



**Issue Fix Video:**


https://github.com/ecency/ecency-vision/assets/106739598/0124d725-831c-4e92-a92b-441a41eb91c7



**Test:**

![test-pass](https://github.com/ecency/ecency-vision/assets/106739598/57d4b9a2-4935-488b-845b-0954897cde47)



**Build:**

![build](https://github.com/ecency/ecency-vision/assets/106739598/fa70fc89-5ca1-47d6-a835-b81e21ee09c0)

